### PR TITLE
Configure broccoli's server to bind to 0.0.0.0 rather than localhost

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -6,8 +6,8 @@ var synchronized = require('synchronized')
 
 exports.serve = serve
 function serve (builder) {
-  console.log('Serving on http://localhost:8000/\n')
-  var server = hapi.createServer('localhost', 8000, {
+  console.log('Serving on http://0.0.0.0:8000/\n')
+  var server = hapi.createServer('0.0.0.0', 8000, {
     views: {
       engines: {
         html: 'handlebars'


### PR DESCRIPTION
Binding to 0.0.0.0 rather than localhost allows broccoli server to play nicely with bonjour/zeroconf. This means development server can be accessed via machine.local or similar.
