### PR TITLE
Prettier --help and --port&--host options

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,7 +24,7 @@ function broccoliCLI () {
 
   if (command === 'serve') {
     if (program.args.length !== 0) program.help()
-    broccoli.server.serve(getBuilder())
+    broccoli.server.serve(getBuilder(), {host: program.host, port: program.port})
   } else if (command === 'build') {
     if (program.args.length !== 1) program.help()
     var outputDir = program.args.shift()

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,13 +5,13 @@ var synchronized = require('synchronized')
 
 
 exports.serve = serve
-function serve (builder) {
-  console.log('Serving on http://0.0.0.0:8000/\n')
+function serve (builder, options) {
+  console.log('Serving on http://' + options.host + ':' + options.port + '/\n')
 
   var buildError = null
   var outputTmpDir = null
 
-  var server = hapi.createServer('0.0.0.0', 8000, {
+  var server = hapi.createServer(options.host, options.port, {
     views: {
       engines: {
         html: 'handlebars'


### PR DESCRIPTION
I've taken the liberty to making the `--help` a bit more useful.

I also added support for `--host` and `--port` options, so users can specify those two things.
