### PR TITLE
Tolerant of Broccolifile.js misspellings

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -198,7 +198,7 @@ function loadBroccolifile () {
     if (broccolifile == null) {
       throw new Error('Broccolifile.js not found')
     } else {
-      console.warn("Warning: Broccolifile.js not found.  Using '"+misspellings[i-1]+"'")
+      console.warn('Warning: Broccolifile.js not found.  Using '+misspellings[i-1]+' instead')
     }
   }
 


### PR DESCRIPTION
Since issue #16 has produced quite some discussion, I thought I'd contribute some code that I think could solve the problem.

`Broccolifile.js` remains the preferred configuration file.  However, if it can't be found, it will use the first misspelling it can find and warn the user on the console.  (This list could easily be adjusted as you see fit.)

This is my first attempt at tinkering with a node.js package, so all advice is welcome!
