### PR TITLE
allow case-insensitive brocfile.js

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -188,7 +188,7 @@ function multiGlob (globs, globOptions) {
 
 exports.loadBrocfile = loadBrocfile
 function loadBrocfile () {
-  var brocfile = findup('Brocfile.js')
+  var brocfile = findup('Brocfile.js', {nocase: true})
   if (brocfile == null) {
     throw new Error('Brocfile.js not found (note: was previously Broccolifile.js)')
   }


### PR DESCRIPTION
Other tools allow lowercase names for their files (rakefile, makefile, vagrantfile, ...). I'd love it if Broccoli got the same treatment.
