### PR TITLE
Replace bower [large] dependency with bower-config [small] dependency

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -101,7 +101,7 @@ Tree._fromDirectory = function (dir) {
 // This is exposed as API, but needs refactoring and will likely change
 exports.bowerTrees = bowerTrees
 function bowerTrees () {
-  var bowerDir = require('bower').config.directory // note: this relies on cwd
+  var bowerDir = require('bower-config').read().directory // note: this relies on cwd
   if (bowerDir == null) throw new Error('Bower did not return a directory')
   var entries = fs.readdirSync(bowerDir)
   var directories = entries.filter(function (f) {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "commander": "~2.0.0",
     "findup-sync": "~0.1.2",
     "tiny-lr": "0.0.5",
-    "bower": "~1.2.8",
     "rsvp": "~3.0.3",
     "ncp": "~0.5.0",
-    "quick-temp": "~0.0.2"
+    "quick-temp": "~0.0.2",
+    "bower-config": "^0.5.0"
   },
   "devDependencies": {
     "jshint": "~2.3.0"


### PR DESCRIPTION
Currently, the only reason Broccoli has a dependency on Bower is to properly read an interpret a `bower.json` file. The trouble is, depending on `bower` means `broccoli` ends up with **191** npm package dependencies!

This can be improved by replacing the `bower` dependency with `bower-config`, which is used internally in `bower` here: https://github.com/bower/bower/blob/master/lib/config.js#L3

This change mimics this usage of `bower-config` and reduces the dependencies down to 77.

Relates to #26
