### PR TITLE
Make sure watcher doesn't trigger multiple simultaneous builds

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -20,9 +20,10 @@ Watcher.prototype.check = function() {
       this.emit('change', directory)
     }.bind(this), function(error) {
       this.emit('error', error)
-    }.bind(this))
+    }.bind(this)).finally(this.check.bind(this))
+  } else {
+    setTimeout(this.check.bind(this), 100)
   }
-  setTimeout(this.check.bind(this), 100)
 }
 
 Watcher.prototype.then = function(success, fail) {


### PR DESCRIPTION
So, this is pretty tricky to test, especially since I have no idea _why_ triggering multiple builds at the same time idea is a bad idea. This seems like a pretty onerous restriction, imo.

Anyway, I _think_ this should work.

As far as I can see, this change is completely independent of #59.
