### PR TITLE
Add option to proxy requests to another server

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,6 +19,7 @@ function broccoliCLI () {
     .option('--port <port>', 'the port to bind to [4200]', 4200)
     .option('--host <host>', 'the host to bind to [localhost]', 'localhost')
     .option('--live-reload-port <port>', 'the port to start LiveReload on [35729]', 35729)
+    .option('--proxy <address>', 'the address of a server to proxy requests to')
     .action(function(options) {
       actionPerformed = true
       broccoli.server.serve(getBuilder(), options)

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,7 @@
 var Watcher = require('./watcher')
 var middleware = require('./middleware')
 var http = require('http')
+var httpProxy = require('http-proxy')
 var tinylr = require('tiny-lr')
 var connect = require('connect')
 
@@ -13,6 +14,10 @@ function serve (builder, options) {
   var watcher = new Watcher(builder)
 
   var app = connect().use(middleware(watcher))
+
+  if(options.proxy) {
+    app.use(httpProxy.createProxyServer({ target: options.proxy }).web)
+  }
 
   var server = http.createServer(app)
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "quick-temp": "^0.1.0",
     "bower-config": "^0.5.0",
     "connect": "~2.14.1",
-    "send": "~0.2.0"
+    "send": "~0.2.0",
+    "http-proxy": "~1.0.2"
   },
   "devDependencies": {
     "jshint": "~2.3.0"


### PR DESCRIPTION
This PR adds a command line option which allows users to proxy requests to another server if they aren't found among the result tree of the broccoli build. This enables a very nice workflow, since users won't have to do any additional work in integrating broccoli into their app. Cookies, AJAX, everything just works. Another neat feature is that build error are always shown in the browser.

I know this idea has previously been shot down by @joliss, but I wanted to show just how simple this is, for a  huge gain in usability. With this very simple PR, broccoli works nicely _right now_ with any web framework. That's good for early adoption, and good for the project in the long term. I do think that the CLI _is_ important, and offering people, especially early adopters, a nice experience is worthwhile, even if the eventual goal is to integrate broccoli with other task running tools.
