### PR TITLE
Force content-type to HTML when it's accepted

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -10,6 +10,13 @@ var errorTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '
 module.exports = function(watcher) {
   return function broccoliMiddleware(request, response, next) {
     watcher.then(function(directory) {
+      
+      // Set HTML on any requests that want it
+      // to handle files that do not end in .html
+      if(request.headers.accept.match('text/html')) {
+        response.setHeader('Content-Type', 'text/html');
+      }
+
       send(request, url.parse(request.url).pathname)
         .root(directory)
         .on('error', function(err) {


### PR DESCRIPTION
I have a case in an ember-cli app where I need to use the `history` location. In order to support it, I want to create copies of `index.html` under public that match my Ember routes. Since Ember routes do not have an extensions, these files cannot end in `.html`, and therefore the broccoli server defaults the mime type to `application/octet-stream` which forces Chrome to download the file.

In lieu of a more configurable broccoli development server, always sending a `Content-Type` of `text/html` when it's accepted worked for me. What do you think?
