### PR TITLE
Allow Brocfiles to be written in CoffeeScript

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -87,7 +87,7 @@ Builder.prototype.cleanup = function () {
 
 exports.loadBrocfile = loadBrocfile
 function loadBrocfile () {
-  var brocfile = findup('Brocfile.js', {nocase: true})
+  var brocfile = findup('Brocfile.{js,coffee}', {nocase: true})
   if (brocfile == null) {
     throw new Error('Brocfile.js not found (note: was previously Broccolifile.js)')
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "bower-config": "^0.5.0",
     "connect": "~2.14.1",
     "send": "~0.2.0",
-    "broccoli-kitchen-sink-helpers": "^0.1.0"
+    "broccoli-kitchen-sink-helpers": "^0.1.0",
+    "coffee-script": "~1.7.1"
   },
   "devDependencies": {
     "jshint": "~2.3.0"


### PR DESCRIPTION
Simple change to the findup regex that will compile coffee based
Brocfiles.
