### PR TITLE
Fixes a bug where modules with main and lib set would get included twice

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -48,18 +48,19 @@ Tree._fromDirectory = function (dir) {
   }
 
   var tree = new Tree(dir)
-  // It's not clear that this is a sensible heuristic to hard-code here
-  if (fs.existsSync(path.join(dir, 'lib'))) {
-    tree.map('lib', '/')
-  }
   if (treeOptions.main) {
     for (var i = 0; i < treeOptions.main.length; i++) {
       tree.map(treeOptions.main[i], '/' + path.basename(treeOptions.main[i]))
     }
   } else {
-    // Map repo root into namespace root. We should perhaps avoid this, as
-    // it causes clutter.
-    tree.map('', '/')
+    if (fs.existsSync(path.join(dir, 'lib'))) {
+      // It's not clear that this is a sensible heuristic to hard-code here
+      tree.map('lib', '/')
+    } else {
+      // Map repo root into namespace root. We should perhaps avoid this, as
+      // it causes clutter.
+      tree.map('', '/')
+    }
   }
 
   return [tree]


### PR DESCRIPTION
This happened because bower modules with an explicit `"main"` entry
always get added. If the bower module also happens to have a `"lib"`
folder, its files would get included twice resulting in a crash in
`fs.writeFileSync`.

See https://github.com/gf3/moment-range for an example of a crashing
dependency.
