### PR TITLE
Allow specifying bower dependencies destination

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 var quickTemp = require('quick-temp')
+var extend = require('xtend')
 
 var helpers = require('broccoli-kitchen-sink-helpers')
 
@@ -36,12 +37,17 @@ Tree.prototype.cleanup = function () {
   quickTemp.remove(this, '_tmpDestDir')
 }
 
-Tree._fromDirectory = function (dir) {
+Tree._fromDirectory = function (dir, options) {
   // Guess some reasonable defaults
-  var options = bowerOptionsForDirectory(dir)
-  var treeOptions = {}
-  if (options.main != null) {
-    var main = options.main
+  var bowerOptions = bowerOptionsForDirectory(dir)
+  var treeOptions = extend({
+    destDir: '/'
+  }, options || {})
+
+  treeOptions.destDir = path.normalize(treeOptions.destDir + '/')
+
+  if (bowerOptions.main != null) {
+    var main = bowerOptions.main
     if (typeof main === 'string') main = [main]
     if (!Array.isArray(main)) throw new Error(dir + ': Expected "main" bower option to be array or string')
     treeOptions.main = main
@@ -50,16 +56,16 @@ Tree._fromDirectory = function (dir) {
   var tree = new Tree(dir)
   // It's not clear that this is a sensible heuristic to hard-code here
   if (fs.existsSync(path.join(dir, 'lib'))) {
-    tree.map('lib', '/')
+    tree.map('lib', treeOptions.destDir)
   }
   if (treeOptions.main) {
     for (var i = 0; i < treeOptions.main.length; i++) {
-      tree.map(treeOptions.main[i], '/' + path.basename(treeOptions.main[i]))
+      tree.map(treeOptions.main[i], treeOptions.destDir + path.basename(treeOptions.main[i]))
     }
   } else {
     // Map repo root into namespace root. We should perhaps avoid this, as
     // it causes clutter.
-    tree.map('', '/')
+    tree.map('', treeOptions.destDir)
   }
 
   return [tree]
@@ -88,7 +94,9 @@ Tree._fromDirectory = function (dir) {
 
 // This is exposed as API, but needs refactoring and will likely change
 exports.bowerTrees = bowerTrees
-function bowerTrees () {
+function bowerTrees (options) {
+  var config = options || {}
+
   var bowerDir = require('bower-config').read().directory // note: this relies on cwd
   if (bowerDir == null) throw new Error('Bower did not return a directory')
   var entries = fs.readdirSync(bowerDir)
@@ -101,7 +109,7 @@ function bowerTrees () {
   })
   var trees = []
   for (var i = 0; i < directories.length; i++) {
-    trees = trees.concat(Tree._fromDirectory(path.join(bowerDir, directories[i])))
+    trees = trees.concat(Tree._fromDirectory(path.join(bowerDir, directories[i]), config))
   }
   // Pick up files as well; this is for compatibility with EAK's vendor/loader.js
   for (i = 0; i < files.length; i++) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "bower-config": "^0.5.0",
     "connect": "~2.14.1",
     "send": "~0.2.0",
-    "broccoli-kitchen-sink-helpers": "^0.2.0"
+    "broccoli-kitchen-sink-helpers": "^0.2.0",
+    "xtend": "^2.2.0"
   },
   "devDependencies": {
     "jshint": "~2.3.0"


### PR DESCRIPTION
Added the ability to specify the destination folder for bower dependencies.

You can do the following, for example:

``` js
broccoli.bowerTrees({ destDir: '/vendor' })
```

Note that this pull request depends on pull request https://github.com/joliss/broccoli-kitchen-sink-helpers/pull/6 due to the use of path.normalize.
