### PR TITLE
Improve handling of undefined input trees

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -57,8 +57,12 @@ Builder.prototype.build = function () {
         dirsCache.push(null)
         index = dirsCache.length - 1
         if (!subtree) {
-          console.error("Unable to read subtree of " + tree);
-          return Promise.reject("Error reading subtree"0;)
+          console.error("Invalid or undefined input tree for", tree)
+          if (tree.tmpDestDir) {
+            var pluginName = tree.tmpDestDir.match(/tmp\/(.+)-tmp/)[1];
+            console.error("HINT: Check the input trees anywhere you use " + pluginName);
+          }
+          return Promise.reject("Error reading subtree of " + tree)
         }
         var subtreeDir = typeof subtree === 'string' ?
            subtree :


### PR DESCRIPTION
Fail the build and log out with a marginally more helpful error message when a subtree is `undefined`.

Right now, if you accidentally pass `undefined` into `mergeTrees`, you get a rather cryptic error:

```
Built with error:
TypeError: Cannot call method 'read' of undefined
  at readTree (node_modules/broccoli/lib/builder.js:61:20)
  at promise.then.then.results.(anonymous function) (node_modules/broccoli-merge-trees/node_modules/promise-map-series/index.js:8:27)
  at invokeCallback (node_modules/broccoli-merge-trees/node_modules/promise-map-series/node_modules/rsvp/dist/commonjs/rsvp/promise.js:228:21)
  at publish (node_modules/broccoli-merge-trees/node_modules/promise-map-series/node_modules/rsvp/dist/commonjs/rsvp/promise.js:176:9)
  at publishFulfillment (node_modules/broccoli-merge-trees/node_modules/promise-map-series/node_modules/rsvp/dist/commonjs/rsvp/promise.js:312:5)
  at flush (node_modules/broccoli-merge-trees/node_modules/promise-map-series/node_modules/rsvp/dist/commonjs/rsvp/asap.js:41:9)
  at process._tickCallback (node.js:415:13)
  at Function.Module.runMain (module.js:499:11)
  at startup (node.js:119:16)
  at node.js:902:3
```

With this PR, you'll at least get:

```
Invalid or undefined input tree for { inputTrees:
   [ { inputTree: 'app',
       options: [Object],
       tmpDestDir: 'tmp/static_compiler-tmp_dest_dir-NVs5IXin.tmp' },
     undefined ],
  options: {},
  tmpDestDir: 'tmp/tree_merger-tmp_dest_dir-NOvdX6OQ.tmp' }
HINT: Check the input trees anywhere you use tree_merger
# followed by the same stack trace as above ...
```

Which can at least clue me in to the fact that the offender is one of my `mergeTrees` calls. Open to other suggestions for how to report this error out.
