### PR TITLE
Show file with build errors.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -51,6 +51,9 @@ function broccoliCLI () {
         })
         .catch(function (err) {
           // Should show file and line/col if present
+          if (err.file) {
+            console.error('File: ' + err.file)
+          }
           console.error(err.stack)
           console.error('\nBuild failed')
           process.exit(1)

--- a/lib/server.js
+++ b/lib/server.js
@@ -50,6 +50,9 @@ function serve (builder, options) {
   watcher.on('error', function(err) {
     console.log('Built with error:')
     // Should also show file and line/col if present; see cli.js
+    if (err.file) {
+      console.log('File: ' + err.file)
+    }
     console.log(err.stack)
     console.log('')
     liveReload()


### PR DESCRIPTION
Adds filename to output from both `broccoli serve` and `broccoli build dist`.
