### PR TITLE
Added broccoli-absurd-filter to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Broccoli plugin.
 * [broccoli-es6-transpiler](https://github.com/sindresorhus/broccoli-es6-transpiler)
 * [broccoli-ember-script](https://github.com/aradabaugh/broccoli-ember-script)
 * [broccoli-bower](https://github.com/joliss/broccoli-bower)
+* [broccoli-absurd-filter] (https://github.com/Xulai/broccoli-absurd-filter)
 
 More plugins may be found under the [broccoli-plugin
 keyword](https://www.npmjs.org/browse/keyword/broccoli-plugin) on npm.


### PR DESCRIPTION
I added the plugin I created for broccoli that allows it to use absurdjs( https://github.com/krasimir/absurd ) as a preprocessor for CSS or HTML files using javascript to create them rather than a new script or css/html like script. -filter is appended as it uses broccoli-filter for one to one whereas idealistically there will be a broccoli-absurd that can do one to two. For one component.js to a component.css and component.html.
