### PR TITLE
Add --force option to `build` command

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,11 +26,16 @@ function broccoliCLI () {
 
   program.command('build <target>')
     .description('output files to target directory')
-    .action(function(outputDir) {
+    .option('--force', 'overwrite existing files')
+    .action(function(outputDir, options) {
       actionPerformed = true
       var builder = getBuilder()
       builder.build()
         .then(function (dir) {
+          if (options.force) {
+            deleteFolderRecursive(outputDir)
+          }
+
           try {
             fs.mkdirSync(outputDir)
           } catch (err) {
@@ -67,4 +72,21 @@ function broccoliCLI () {
 function getBuilder () {
   var tree = broccoli.loadBrocfile()
   return new broccoli.Builder(tree)
+}
+
+// taken from http://stackoverflow.com/a/12761924/65542
+function deleteFolderRecursive (path) {
+  var files = []
+  if( fs.existsSync(path) ) {
+    files = fs.readdirSync(path)
+    files.forEach(function(file, index) {
+      var curPath = path + '/' + file
+      if(fs.lstatSync(curPath).isDirectory()) {
+        deleteFolderRecursive(curPath)
+      } else {
+        fs.unlinkSync(curPath)
+      }
+    })
+    fs.rmdirSync(path)
+  }
 }


### PR DESCRIPTION
If specified, existing files in the target directory will be overwritten when `broccoli build` is invoked. The contents of the folder are removed recursively.

This addresses #103
