### PR TITLE
Bring back simple build/rebuild timer.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -6,6 +6,7 @@ var Promise = require('rsvp').Promise
 exports.Builder = Builder
 function Builder (tree) {
   this.tree = tree
+  this.buildTime = null;
   this.treesRead = [] // last build
   this.allTreesRead = [] // across all builds
 }
@@ -15,6 +16,7 @@ Builder.prototype.build = function () {
 
   var newTreesRead = []
   var dirsCache = []
+  var startTime = Date.now()
 
   return Promise.resolve()
     .then(function () {
@@ -44,6 +46,9 @@ Builder.prototype.build = function () {
         err = new Error(err + ' [string exception]')
       }
       throw err
+    })
+    .finally(function() {
+      self.buildTime = Date.now() - startTime
     })
 
   function getReadTreeFn (tree) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -43,7 +43,7 @@ function serve (builder, options) {
   }
 
   watcher.on('change', function(dir) {
-    console.log('Built')
+    console.log('Built - ' + builder.buildTime)
     liveReload()
   })
 


### PR DESCRIPTION
Adds the total milliseconds for a build to `Builder.prototype.buildTime` and is calculated at the end of a `Builder.prototype.build` run.

Does not offer nearly the same ability that was removed in https://github.com/joliss/broccoli/commit/0fcb34b2ec0a8fe22720bb597796ba5e0d705757, but it is useful to generally know if your build time is over/under some reasonable number.
