### PR TITLE
Allow Watcher interval to be configurable.

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -4,8 +4,9 @@ var helpers = require('broccoli-kitchen-sink-helpers')
 
 
 module.exports = Watcher
-function Watcher(builder) {
+function Watcher(builder, options) {
   this.builder = builder
+  this.options = options || {}
   this.check()
 }
 
@@ -14,6 +15,7 @@ Watcher.prototype.constructor = Watcher
 
 Watcher.prototype.check = function() {
   try {
+    var interval = this.options.interval || 100
     var newStatsHash = this.builder.treesRead.map(function (tree) {
       return typeof tree === 'string' ? helpers.hashTree(tree) : ''
     }).join('\x00')
@@ -28,7 +30,7 @@ Watcher.prototype.check = function() {
         throw error
       }.bind(this)).finally(this.check.bind(this))
     } else {
-      setTimeout(this.check.bind(this), 100)
+      setTimeout(this.check.bind(this), interval)
     }
   } catch (err) {
     console.error('Uncaught error in Broccoli file watcher:')


### PR DESCRIPTION
Running `broccoli serve` on the Ember code base takes approximately 13.5% CPU
on a rMBP. Modifying this interval to 250 cuts that to approximately 6%.
