### PR TITLE
Allow custom watcher for serve command.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ function serve (builder, options) {
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
 
-  var watcher = new Watcher(builder)
+  var watcher = options.watcher || new Watcher(builder)
 
   var app = connect().use(middleware(watcher))
 


### PR DESCRIPTION
I would like to be able to use a custom Watcher with the serve function. I
obviously could duplicate the code that exists in `lib/server.js`, but the
only tweak I would like to make is to pass a different watcher.
