### PR TITLE
Allow passing new tree into `Builder.prototype.build`.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -4,14 +4,13 @@ var Promise = require('rsvp').Promise
 
 
 exports.Builder = Builder
-function Builder (tree) {
-  this.tree = tree
+function Builder () {
   this.buildTime = null;
   this.treesRead = [] // last build
   this.allTreesRead = [] // across all builds
 }
 
-Builder.prototype.build = function () {
+Builder.prototype.build = function (tree) {
   var self = this
 
   var newTreesRead = []
@@ -20,7 +19,7 @@ Builder.prototype.build = function () {
 
   return Promise.resolve()
     .then(function () {
-      return getReadTreeFn(null)(self.tree) // call self.tree.read()
+      return getReadTreeFn(null)(tree) // call self.tree.read()
     })
     .then(function (dir) {
       self.treesRead = newTreesRead

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,15 +21,17 @@ function broccoliCLI () {
     .option('--live-reload-port <port>', 'the port to start LiveReload on [35729]', 35729)
     .action(function(options) {
       actionPerformed = true
-      broccoli.server.serve(getBuilder(), options)
+      broccoli.server.serve(options)
     })
 
   program.command('build <target>')
     .description('output files to target directory')
     .action(function(outputDir) {
       actionPerformed = true
-      var builder = getBuilder()
-      builder.build()
+      var tree = broccoli.loadBrocfile()
+      var builder = broccoli.Builder()
+
+      builder.build(tree)
         .then(function (dir) {
           try {
             fs.mkdirSync(outputDir)
@@ -65,9 +67,4 @@ function broccoliCLI () {
     program.outputHelp()
     process.exit(1)
   }
-}
-
-function getBuilder () {
-  var tree = broccoli.loadBrocfile()
-  return new broccoli.Builder(tree)
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,28 +5,16 @@ var tinylr = require('tiny-lr')
 var connect = require('connect')
 
 exports.serve = serve
-function serve (builder, options) {
+function serve (options) {
   options = options || {}
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
 
-  var watcher = options.watcher || new Watcher(builder)
+  var watcher = options.watcher || new Watcher()
 
   var app = connect().use(middleware(watcher))
 
   var server = http.createServer(app)
-
-  process.addListener('exit', function () {
-    builder.cleanup()
-  })
-
-  // We register these so the 'exit' handler removing temp dirs is called
-  process.on('SIGINT', function () {
-    process.exit(1)
-  })
-  process.on('SIGTERM', function () {
-    process.exit(1)
-  })
 
   var livereloadServer = new tinylr.Server
   livereloadServer.listen(options.liveReloadPort, function (err) {
@@ -43,7 +31,7 @@ function serve (builder, options) {
   }
 
   watcher.on('change', function(dir) {
-    console.log('Built - ' + builder.buildTime)
+    console.log('Built - ' + watcher.builder.buildTime)
     liveReload()
   })
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,12 +1,15 @@
 var EventEmitter = require('events').EventEmitter
 
+var broccoli = require('./index')
 var helpers = require('broccoli-kitchen-sink-helpers')
 
 
 module.exports = Watcher
-function Watcher(builder, options) {
-  this.builder = builder
+function Watcher(tree, options) {
+  this.tree    = tree    || broccoli.loadBrocfile()
   this.options = options || {}
+  this.builder = new broccoli.Builder()
+  this.setupExitHooks()
   this.check()
 }
 
@@ -21,7 +24,7 @@ Watcher.prototype.check = function() {
     }).join('\x00')
     if (newStatsHash !== this.statsHash) {
       this.statsHash = newStatsHash
-      this.current = this.builder.build()
+      this.current = this.builder.build(this.tree)
       this.current.then(function(directory) {
         this.emit('change', directory)
         return directory
@@ -41,4 +44,18 @@ Watcher.prototype.check = function() {
 
 Watcher.prototype.then = function(success, fail) {
   return this.current.then(success, fail)
+}
+
+Watcher.prototype.setupExitHooks = function setupExitHooks() {
+  process.addListener('exit', function () {
+    this.builder.cleanup()
+  })
+
+  // We register these so the 'exit' handler removing temp dirs is called
+  process.on('SIGINT', function () {
+    process.exit(1)
+  })
+  process.on('SIGTERM', function () {
+    process.exit(1)
+  })
 }

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -37,6 +37,22 @@ test('Builder', function (t) {
         })
       })
 
+      test('can change starting tree with param', function (t) {
+        var builder = new Builder({
+          read: function (readTree) { return 'someDir' }
+        })
+        builder.build().then(function (dir) {
+          t.equal(dir, 'someDir')
+        })
+        .then(function() {
+          builder.build('someOther').then(function (dir) {
+            t.equal(dir, 'someOther')
+            t.equal(builder.tree, 'someOther')
+            t.end()
+          })
+        })
+      })
+
       t.end()
     })
 


### PR DESCRIPTION
This allows the tree to be modified on running instance (will likely be useful
in testing scenarios for example).
