### PR TITLE
Make Watcher emit the `build()` output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Change `Watcher`'s `change` event to provide the full build results (instead of just the directory).
+
 # 0.10.0
 
 * Move process.exit listener out of builder into server

--- a/lib/server.js
+++ b/lib/server.js
@@ -42,8 +42,8 @@ function serve (builder, options) {
     livereloadServer.changed({body: {files: ['LiveReload files']}})
   }
 
-  watcher.on('change', function(dir) {
-    console.log('Built - ' + builder.buildTime)
+  watcher.on('change', function(results) {
+    console.log('Built - ' + results.graph.totalTime / 1e6)
     liveReload()
   })
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -23,9 +23,7 @@ Watcher.prototype.check = function() {
       this.statsHash = newStatsHash
       this.current = this.builder.build()
       this.current.then(function(hash) {
-        var directory = hash.directory
-        this.emit('change', directory)
-        return directory
+        this.emit('change', hash)
       }.bind(this), function(error) {
         this.emit('error', error)
         throw error


### PR DESCRIPTION
This allows introspection upon rebuild (i.e. time tracking).

---

Since we do not export the watcher directly, does this change require `0.11` or can this be a minor bump (say `0.10.1`)?
