### PR TITLE
Provide the totalTime at the top level of the `Builder::build` output.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -6,7 +6,6 @@ var Promise = require('rsvp').Promise
 exports.Builder = Builder
 function Builder (tree) {
   this.tree = tree
-  this.buildTime = null;
   this.treesRead = [] // last build
   this.allTreesRead = [] // across all builds
 }
@@ -16,7 +15,6 @@ Builder.prototype.build = function () {
 
   var newTreesRead = []
   var nodeCache = []
-  var startTime = Date.now()
 
   return Promise.resolve()
     .then(function () {
@@ -24,7 +22,7 @@ Builder.prototype.build = function () {
     })
     .then(function (node) {
       self.treesRead = newTreesRead
-      return { directory: node.directory, graph: node }
+      return { directory: node.directory, graph: node, totalTime: node.totalTime }
     }, function (err) {
       // self.treesRead is used by the watcher. Do not stop watching
       // directories if the build errors in the middle, or we get double
@@ -46,9 +44,6 @@ Builder.prototype.build = function () {
         err = new Error(err + ' [string exception]')
       }
       throw err
-    })
-    .finally(function() {
-      self.buildTime = Date.now() - startTime
     })
 
   // Read the `tree` and return its node, which in particular contains the


### PR DESCRIPTION
Also, removes the crude timing that is hung off of the `Builder` instance
itself.
