### PR TITLE
Add slow tree logging to `broccoli serve`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 * Change `Watcher`'s `change` event to provide the full build results (instead of just the directory).
+* Add slow tree logging to `broccoli serve` output.
 
 # 0.10.0
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,6 @@ ncp.limit = 1
 
 var broccoli = require('./index')
 
-
 module.exports = broccoliCLI
 function broccoliCLI () {
   var actionPerformed = false

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,67 @@
+module.exports.printSlowTrees = printSlowTrees
+
+function printSlowTrees(graph, factor) {
+  var sortedTrees = sortResults(graph)
+  var minimumTime = graph.totalTime * (factor || 0.05)
+  var logLines = []
+
+  for (var i = 0; i < sortedTrees.length; i++) {
+    var node = sortedTrees[i]
+    var name = node.tree.description || node.tree.constructor.name
+
+    if (node.selfTime > minimumTime) {
+      logLines.push(pad(name, 30) + ' | ' + pad(Math.floor(node.selfTime / 1e6) + 'ms', 15))
+    }
+  }
+
+  if (logLines.length > 0) {
+    logLines.unshift(pad('', 30, '-') + '-+-' + pad('', 15, '-'))
+    logLines.unshift(pad('Slowest Trees', 30) + ' | ' + pad('Total', 15))
+  }
+
+  console.log('\n' + logLines.join('\n') + '\n')
+}
+
+function sortResults(graph) {
+  var flattenedTrees = []
+
+  function process(node) {
+    if (flattenedTrees.indexOf(node) > -1) { return } // for de-duping
+
+    flattenedTrees.push(node)
+
+    var length = node.subtrees.length
+    for (var i = 0; i < length; i++) {
+      process(node.subtrees[i])
+    }
+  }
+
+  process(graph) // kick off with the top item
+
+  return flattenedTrees.sort(function(a, b) {
+    return b.selfTime - a.selfTime
+  })
+}
+
+function pad(str, len, char, dir) {
+  if (!char) { char = ' '}
+
+  if (len + 1 >= str.length)
+    switch (dir){
+      case 'left':
+        str = Array(len + 1 - str.length).join(char) + str
+        break
+
+      case 'both':
+        var padlen = len - str.length
+        var right = Math.ceil(padlen / 2)
+        var left = padlen - right
+        str = Array(left + 1).join(char) + str + Array(right + 1).join(char)
+        break
+
+      default:
+        str = str + Array(len + 1 - str.length).join(char)
+    }
+
+  return str
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ function serve (builder, options) {
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
 
-  var watcher = options.watcher || new Watcher(builder)
+  var watcher = options.watcher || new Watcher(builder, {verbose: true})
 
   var app = connect().use(middleware(watcher))
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,6 +1,7 @@
 var EventEmitter = require('events').EventEmitter
 
 var helpers = require('broccoli-kitchen-sink-helpers')
+var printSlowTrees = require('./logging').printSlowTrees
 
 
 module.exports = Watcher
@@ -23,6 +24,9 @@ Watcher.prototype.check = function() {
       this.statsHash = newStatsHash
       this.current = this.builder.build()
       this.current.then(function(hash) {
+        if (this.options.verbose) {
+          printSlowTrees(hash.graph)
+        }
         this.emit('change', hash)
       }.bind(this), function(error) {
         this.emit('error', error)


### PR DESCRIPTION
Sample output from the Ember Broccolification effort (from `broccoli serve`):

```
% broccoli serve
Serving on http://localhost:4200


Slowest Trees                  | Total
-------------------------------+----------------
DefeatureifyFilter             | 3630ms
DefeatureifyFilter             | 1663ms
TranspilerFilter               | 1610ms
TranspilerFilter               | 647ms

Built - 7955 ms

Slowest Trees                  | Total
-------------------------------+----------------
DefeatureifyFilter             | 92ms
TranspilerFilter               | 88ms
TreeMerger                     | 69ms
TranspilerFilter               | 68ms
Concat                         | 65ms
TreeMerger                     | 57ms
DefeatureifyFilter             | 46ms

Built - 771 ms
```
