### PR TITLE
Prevent double initial builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Update `Watcher` and `Builder` interaction to prevent double builds.
+
 # 0.11.0
 
 * Change `Watcher`'s `change` event to provide the full build results (instead of just the directory).

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -6,11 +6,10 @@ var Promise = require('rsvp').Promise
 exports.Builder = Builder
 function Builder (tree) {
   this.tree = tree
-  this.treesRead = [] // last build
   this.allTreesRead = [] // across all builds
 }
 
-Builder.prototype.build = function () {
+Builder.prototype.build = function (addWatchDirCb) {
   var self = this
 
   var newTreesRead = []
@@ -21,16 +20,7 @@ Builder.prototype.build = function () {
       return readAndReturnNodeFor(self.tree) // call self.tree.read()
     })
     .then(function (node) {
-      self.treesRead = newTreesRead
       return { directory: node.directory, graph: node, totalTime: node.totalTime }
-    }, function (err) {
-      // self.treesRead is used by the watcher. Do not stop watching
-      // directories if the build errors in the middle, or we get double
-      // rebuilds.
-      if (newTreesRead.length > self.treesRead.length) {
-        self.treesRead = newTreesRead
-      }
-      throw err
     })
     .finally(function () {
       for (var i = 0; i < newTreesRead.length; i++) {
@@ -71,6 +61,7 @@ Builder.prototype.build = function () {
     nodeCache.push(node)
     var treeDirPromise
     if (typeof tree === 'string') {
+      if (addWatchDirCb) { addWatchDirCb(tree) }
       treeDirPromise = Promise.resolve(tree)
     } else if (!tree || typeof tree.read !== 'function') {
       throw new Error('Invalid tree found. You must supply a path or an object with a `read` function.');

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -8,21 +8,41 @@ module.exports = Watcher
 function Watcher(builder, options) {
   this.builder = builder
   this.options = options || {}
+  this.watchedDirs = {}
+
   this.check()
 }
 
 Watcher.prototype = Object.create(EventEmitter.prototype)
 Watcher.prototype.constructor = Watcher
 
+Watcher.prototype.addWatchDir = function (path) {
+  this.watchedDirs[path] = helpers.hashTree(path)
+}
+
+Watcher.prototype.detectChanges = function () {
+  var changedDirs = [];
+
+  for (var dir in this.watchedDirs) {
+    if (this.watchedDirs.hasOwnProperty(dir)) {
+      var currentHash = helpers.hashTree(dir)
+      if (this.watchedDirs[dir] !== currentHash) {
+        changedDirs.push(dir)
+      }
+    }
+  }
+
+  return changedDirs;
+}
+
 Watcher.prototype.check = function() {
   try {
     var interval = this.options.interval || 100
-    var newStatsHash = this.builder.treesRead.map(function (tree) {
-      return typeof tree === 'string' ? helpers.hashTree(tree) : ''
-    }).join('\x00')
-    if (newStatsHash !== this.statsHash) {
-      this.statsHash = newStatsHash
-      this.current = this.builder.build()
+    var changedDirs = this.detectChanges();
+
+    if (Object.keys(this.watchedDirs).length === 0 || changedDirs.length > 0) {
+      this.watchedDirs = {}
+      this.current = this.builder.build(this.addWatchDir.bind(this))
       this.current.then(function(hash) {
         if (this.options.verbose) {
           printSlowTrees(hash.graph)


### PR DESCRIPTION
Pass a callback function from the Watcher into `Builder::build`. This callback is called everytime a plan string tree is found. The watcher uses this to keep track of what directories it is watching.
