### PR TITLE
Remove uncatchable error in promise.

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -50,7 +50,6 @@ Watcher.prototype.check = function() {
         this.emit('change', hash)
       }.bind(this), function(error) {
         this.emit('error', error)
-        throw error
       }.bind(this)).finally(this.check.bind(this))
     } else {
       setTimeout(this.check.bind(this), interval)


### PR DESCRIPTION
Throwing the error here is not catchable (since we do not return the newly created promise) and will always be unhandled.

Closes #81.
