### PR TITLE
Add `didBuild`, `didError`, and `willBuild` to `Watcher`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update `Watcher` and `Builder` interaction to prevent double builds.
 * Avoid unhandled rejected promise
 * Fix trailing slash handling in server on Windows
+* Add `willBuild`, `didError`, and `didBuild` callbacks to `Watcher`. These will be called before (`willBuild`) and after (`didBuild`) building.
 
 # 0.11.0
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,5 +1,7 @@
 var EventEmitter = require('events').EventEmitter
 
+var RSVP    = require('rsvp');
+var Promise = RSVP.Promise;
 var helpers = require('broccoli-kitchen-sink-helpers')
 var printSlowTrees = require('./logging').printSlowTrees
 
@@ -42,15 +44,35 @@ Watcher.prototype.check = function() {
 
     if (Object.keys(this.watchedDirs).length === 0 || changedDirs.length > 0) {
       this.watchedDirs = {}
-      this.current = this.builder.build(this.addWatchDir.bind(this))
-      this.current.then(function(hash) {
-        if (this.options.verbose) {
-          printSlowTrees(hash.graph)
-        }
-        this.emit('change', hash)
-      }.bind(this), function(error) {
-        this.emit('error', error)
-      }.bind(this)).finally(this.check.bind(this))
+      Promise.resolve()
+        .then(function () {
+          if (this.options.willBuild) {
+            return this.options.willBuild(changedDirs)
+          }
+        }.bind(this))
+        .then(function () {
+          this.current = this.builder.build(this.addWatchDir.bind(this))
+          this.current
+          .then(function (hash) {
+            return Promise.resolve()
+              .then(function() {
+                if (this.options.didBuild) this.options.didBuild(hash)
+              }.bind(this))
+              .then(function() { return hash; });
+          }.bind(this))
+          .then(function (hash) {
+            if (this.options.verbose) printSlowTrees(hash.graph)
+
+            this.emit('change', hash)
+          }.bind(this))
+          .catch(function(error) {
+            if (this.options.didError) this.options.didError(error)
+
+            this.emit('error', error)
+          }.bind(this))
+          .finally(this.check.bind(this))
+        }.bind(this))
+        .catch(RSVP.rethrow)
     } else {
       setTimeout(this.check.bind(this), interval)
     }


### PR DESCRIPTION
This allows consumers to do convienient things (like locking) before and after building.