### PR TITLE
Make it possible to pass custom middleware to the Broccoli server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -9,10 +9,15 @@ function serve (builder, options) {
   options = options || {}
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
+  var app = connect()
+
+  var customMiddlewares = options.middleware || []
+  customMiddlewares.forEach(function(customMiddleware) {
+    app.use(customMiddleware)
+  })
 
   var watcher = options.watcher || new Watcher(builder, {verbose: true})
-
-  var app = connect().use(middleware(watcher))
+  app.use(middleware(watcher))
 
   var server = http.createServer(app)
 


### PR DESCRIPTION
Very useful for things like adding CORS headers, like so:

``` javascript
var corsMiddleware = function(req, res, next) {
  res.setHeader('Access-Control-Allow-Origin', '*')
  next()
}

broccoli.server.serve(builder, {host: 'localhost', port: 4200, middleware: [corsMiddleware]})
```
