### PR TITLE
Browse folders with broccoli serve

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -6,6 +6,7 @@ var url = require('url')
 var mime = require('mime')
 
 var errorTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '../templates/error.html')).toString())
+var dirTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '../templates/dir.html')).toString())
 
 module.exports = function(watcher) {
   return function broccoliMiddleware(request, response, next) {
@@ -24,11 +25,6 @@ module.exports = function(watcher) {
         return
       }
 
-      // handle document index
-      if (filename[filename.length - 1] === path.sep) {
-        filename += 'index.html'
-      }
-
       try {
         stat = fs.statSync(filename)
       } catch (e) {
@@ -37,13 +33,37 @@ module.exports = function(watcher) {
         return
       }
 
-      // if directory redirect with trailing slash
       if (stat.isDirectory()) {
-        urlObj.pathname += '/'
-        response.setHeader('Location', url.format(urlObj))
-        response.writeHead(301)
-        response.end()
-        return
+        // if no trailing slash, redirect
+        if (filename[filename.length - 1] !== path.sep) {
+          urlObj.pathname += '/'
+          response.setHeader('Location', url.format(urlObj))
+          response.writeHead(301)
+          response.end()
+          return
+        }
+
+        // if folder doesn't contain an index.html file,
+        // browse the folder
+        if (!fs.existsSync(filename + 'index.html')) {
+          response.writeHead(200)
+          response.end(dirTemplate({
+            url: request.url,
+            files: fs.readdirSync(filename).map(function(child){
+              var stat = fs.statSync(path.join(filename,child)),
+                isDir = stat.isDirectory()
+              return {
+                href: child + ( isDir ? '/' : '' ),
+                type: isDir ? 'dir' : path.extname(child).replace('.','').toLowerCase()
+              }
+            })
+          }))
+          return;
+        }
+
+        // otherwise serve index.html
+        filename += 'index.html'
+        stat = fs.statSync(filename)
       }
 
       lastModified = stat.mtime.toUTCString()

--- a/templates/dir.html
+++ b/templates/dir.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{url}}</title>
+    <style>
+      body {
+        font-family: 'Helvetica Neue','Arial',sans-serif;
+        font-weight: 200;
+      }
+
+      ul {
+        padding: 0;
+        margin: 0;
+        list-style: none;
+      }
+
+      li {
+        background: no-repeat 0 3px;
+        padding: 6px 0 6px 30px;
+        background-image: url(data:image/gif;base64,R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADaDi6vPEwDECrnSO+aTvPEQcIAmGaIrhR5XmKgMq1LkoMN7ECrjDWp52r0iPpJJ0KjUAq7SxLE+sI+9V8vycFiM0iLb2O80s8JcfVJJTaGYrZYPNby5Ov6WolPD+XDJqAgSQ4EUCGQQEJADs=);
+      }
+
+      /* public domain icons via http://www.apache.org/icons/ */
+      .parent {
+        background-image: url(data:image/gif;base64,R0lGODlhFAAWAMIAAP///8z//5mZmWZmZjMzMwAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADSxi63P4jEPJqEDNTu6LO3PVpnDdOFnaCkHQGBTcqRRxuWG0v+5LrNUZQ8QPqeMakkaZsFihOpyDajMCoOoJAGNVWkt7QVfzokc+LBAA7);
+        padding-bottom: 6px;
+        margin-bottom: 6px;
+        border-bottom: 1px solid #ddd;
+      }
+
+      .dir {
+        background-image: url(data:image/gif;base64,R0lGODlhFAAWAMIAAP/////Mmcz//5lmMzMzMwAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAACACwAAAAAFAAWAAADVCi63P4wyklZufjOErrvRcR9ZKYpxUB6aokGQyzHKxyO9RoTV54PPJyPBewNSUXhcWc8soJOIjTaSVJhVphWxd3CeILUbDwmgMPmtHrNIyxM8Iw7AQA7);
+      }
+
+      /* images */
+      .png, .jpg, .gif {
+        background-image: url(data:image/gif;base64,R0lGODlhFAAWAOMAAP////8zM8z//8zMzJmZmWZmZmYAADMzMwCZzACZMwAzZgAAAAAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAACACwAAAAAFAAWAAAEkPDISae4WBzAu99Hdm1eSYYZWXYqOgJBLAcDoNrYNssGsBy/4GsX6y2OyMWQ2OMQngSlBjZLWBM1AFSqkyU4A2tWywUMYt/wlTSIvgYGA/Zq3QwU7mmHvh4g8GUsfAUHCH95NwMHV4SGh4EdihOOjy8rZpSVeiV+mYCWHncKo6Sfm5cliAdQrK1PQBlJsrNSEQA7);
+      }
+
+      /* text files */
+      .txt, .md, .css, .js, .json {
+        background-image: url(data:image/gif;base64,R0lGODlhFAAWAMIAAP///8z//5mZmTMzMwAAAAAAAAAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADWDi6vPEwDECrnSO+aTvPEddVIriN1wVxROtSxBDPJwq7bo23luALhJqt8gtKbrsXBSgcEo2spBLAPDp7UKT02bxWRdrp94rtbpdZMrrr/A5+8LhPFpHajQkAOw==);
+      }
+
+      /* compressed files */
+      .zip, .gz {
+        background-image: url(data:image/gif;base64,R0lGODlhFAAWAOcAAP//////zP//mf//Zv//M///AP/M///MzP/Mmf/MZv/MM//MAP+Z//+ZzP+Zmf+ZZv+ZM/+ZAP9m//9mzP9mmf9mZv9mM/9mAP8z//8zzP8zmf8zZv8zM/8zAP8A//8AzP8Amf8AZv8AM/8AAMz//8z/zMz/mcz/Zsz/M8z/AMzM/8zMzMzMmczMZszMM8zMAMyZ/8yZzMyZmcyZZsyZM8yZAMxm/8xmzMxmmcxmZsxmM8xmAMwz/8wzzMwzmcwzZswzM8wzAMwA/8wAzMwAmcwAZswAM8wAAJn//5n/zJn/mZn/Zpn/M5n/AJnM/5nMzJnMmZnMZpnMM5nMAJmZ/5mZzJmZmZmZZpmZM5mZAJlm/5lmzJlmmZlmZplmM5lmAJkz/5kzzJkzmZkzZpkzM5kzAJkA/5kAzJkAmZkAZpkAM5kAAGb//2b/zGb/mWb/Zmb/M2b/AGbM/2bMzGbMmWbMZmbMM2bMAGaZ/2aZzGaZmWaZZmaZM2aZAGZm/2ZmzGZmmWZmZmZmM2ZmAGYz/2YzzGYzmWYzZmYzM2YzAGYA/2YAzGYAmWYAZmYAM2YAADP//zP/zDP/mTP/ZjP/MzP/ADPM/zPMzDPMmTPMZjPMMzPMADOZ/zOZzDOZmTOZZjOZMzOZADNm/zNmzDNmmTNmZjNmMzNmADMz/zMzzDMzmTMzZjMzMzMzADMA/zMAzDMAmTMAZjMAMzMAAAD//wD/zAD/mQD/ZgD/MwD/AADM/wDMzADMmQDMZgDMMwDMAACZ/wCZzACZmQCZZgCZMwCZAABm/wBmzABmmQBmZgBmMwBmAAAz/wAzzAAzmQAzZgAzMwAzAAAA/wAAzAAAmQAAZgAAM+4AAN0AALsAAKoAAIgAAHcAAFUAAEQAACIAABEAAADuAADdAAC7AACqAACIAAB3AABVAABEAAAiAAARAAAA7gAA3QAAuwAAqgAAiAAAdwAAVQAARAAAIgAAEe7u7t3d3bu7u6qqqoiIiHd3d1VVVURERCIiIhEREQAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAAkACwAAAAAFAAWAAAImQBJCCTBqmDBgQgTDmQFAABDVgojEmzI0KHEhBUrWrwoMGNDihwnAvjHiqRJjhX/qVz5D+VHAFZiWmmZ8BGHji9hxqTJ4ZFAmzc1vpxJgkPPn0Y5CP04M6lPEkCN5mxoJelRqFY5TM36NGrPqV67Op0KM6rYnkup/gMq1mdamC1tdn36lijUpwjr0pSoFyUrmTJLhiTBkqXCgAA7)
+      }
+
+      /* movies */
+      .mp4, .mov, .avi {
+        background-image: url(data:image/gif;base64,R0lGODlhFAAWAMIAAP///8z//8zMzJmZmWZmZjMzMwAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADZmi63BrQCOHaNCVewjsHEpUFDDGc6AAuY2iY6Qle7RbLbrvA8arUFF5qJtIEb6pcZAFoOp0MYIVBM748HSJmqRCifFuS7aaVenFV0g4JNrOV4iMZznjao9apIu3SwwMFgYKDhIEQCQA7);
+      }
+
+      /* audio */
+      .wav, .mp3, .aiff, .flac, .ogg {
+        background-image: url(data:image/gif;base64,R0lGODlhFAAWAMIAAP///8z//8zMzJmZmWZmZjMzMwAAAAAAACH+TlRoaXMgYXJ0IGlzIGluIHRoZSBwdWJsaWMgZG9tYWluLiBLZXZpbiBIdWdoZXMsIGtldmluaEBlaXQuY29tLCBTZXB0ZW1iZXIgMTk5NQAh+QQBAAABACwAAAAAFAAWAAADUBi63P7OSPikLXRZQySmGyF6UCgKV8mdm/FFHHqRVVvcNOzdSt7sr4CPMRS6VC8bsmcADIrMT/M5VBo3QYkzh81ufTce0Zph7sqMcBDNXiQAADs=);
+      }
+    </style>
+  </head>
+  <body>
+    <h1>{{url}}</h1>
+    <ul>
+      <li class='parent'><a href='..'>parent directory</li>
+      {{#each files}}
+        <li class='{{type}}'>
+          <a href='{{href}}'>{{href}}</a>
+        </li>
+      {{/each}}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
For debugging, it's incredibly useful to be able to browse the outputted tree as a directory. This PR adds that to broccoli serve - if a URL resolves to a directory, then
1. if it doesn't have a trailing slash, it redirects (current behaviour), then
2. if it has an index.html file, that file is served (current behaviour),
3. otherwise, a folder view is rendered (new behaviour):

![screen shot 2014-05-28 at 1 53 09 pm](https://cloud.githubusercontent.com/assets/1162160/3108642/8bd89e94-e692-11e3-9264-1b5697d70df0.png)

I realise this is quite an opinionated PR but I hope you'll consider merging it, it's helped my productivity a lot. Thanks!
