### PR TITLE
Better build failure error handling

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -50,9 +50,15 @@ function broccoliCLI () {
           process.exit(0)
         })
         .catch(function (err) {
-          // Should show file and line/col if present
+          if (err.message) {
+            console.error(err.message)
+          }
           if (err.file) {
-            console.error('File: ' + err.file)
+            var file = err.file
+            if (err.line) {
+              file += err.col ? ' ('+err.line+':'+err.col+')' : ' ('+err.line+')'
+            }
+            console.error('File: ' + file)
           }
           console.error(err.stack)
           console.error('\nBuild failed')


### PR DESCRIPTION
The current "Build failed" handling can hide relevant error information:

https://github.com/broccolijs/broccoli/blob/7e5048dec8823f937f0d59f57478f5f50559c6c8/lib/cli.js#L53-L59

For instance, UglifyJS has detailed information about parse errors that doesn't get shown by Broccoli. 

We could call `toString` on the error, but in this case we'd get a double stack trace since UglifyJS adds the trace to `toString`. I wonder if we should hide the trace by default and then allow for a `--trace` flag. This is common practice in some other libraries.
