### PR TITLE
Watch

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,6 +29,10 @@ function broccoliCLI () {
       actionPerformed = true
       var watcher = new broccoli.Watcher(getBuilder(), {verbose: true})
       watcher.on("change", function(path) {
+        if(!fs.lstatSync(outputDir).isSymbolicLink()) {
+          console.error('Error: "' + outputDir + '" already exists and is not a symbolic link. Refusing to overwrite files.')
+          process.exit(1)
+        }
         fs.unlink(outputDir, function(err) {
           fs.symlink(path.directory, outputDir, "dir")
         })

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -23,6 +23,18 @@ function broccoliCLI () {
       broccoli.server.serve(getBuilder(), options)
     })
 
+  program.command('watch <target>')
+    .description('output files to target directory and keep it up to date')
+    .action(function(outputDir) {
+      actionPerformed = true
+      var watcher = new broccoli.Watcher(getBuilder(), {verbose: true})
+      watcher.on("change", function(path) {
+        fs.unlink(outputDir, function(err) {
+          fs.symlink(path.directory, outputDir, "dir")
+        })
+      })
+    })
+
   program.command('build <target>')
     .description('output files to target directory')
     .action(function(outputDir) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var builder = require('./builder')
 exports.Builder = builder.Builder
+exports.Watcher = require('./watcher')
 exports.loadBrocfile = builder.loadBrocfile
 var server = require('./server')
 exports.server = server


### PR DESCRIPTION
A simple solution to #70. It simply uses the watcher and updates a symlink whenever the target has changed. This seems to work very well for me. It also complains if the target already exists and isn't a symlink. I think this is a good solution because it is safe (accidentally overwriting a symlink isn't that bad), it's simple, and it's performant (no unnecessary copying).