### PR TITLE
Added a timestamp to build output

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -43,7 +43,7 @@ function serve (builder, options) {
   }
 
   watcher.on('change', function(results) {
-    console.log('Built - ' + Math.round(results.totalTime / 1e6) + ' ms')
+    console.log('Built - ' + Math.round(results.totalTime / 1e6) + ' ms @ ' + new Date().toString())
     liveReload()
   })
 


### PR DESCRIPTION
When running `broccoli serve`, it is sometimes hard to tell if a change got picked up. Adding a timestamp to the output enables just that.
