### PR TITLE
Support for .brocfileLocation in error objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ easier to track down by setting the `.file` property on the generated error.
 This `.file` property is used by both the console logging, and the server middleware
 to display more helpful error messages.
 
+Due to the asynchronous architecture of Broccoli, stack traces may not reflect the
+original source of errors. To prevent this, the stack may be collected at the plugin's
+constructor with `new Error().stack` and then injected into the `.brocfileLocation`
+property on the thrown error object.
+
+When present, the `.brocfileLocation` property will replace the actual stack trace
+in the console logging.
+
 #### Descriptive Naming
 
 As of 0.11 Broccoli prints a log of any trees that took a significant amount of the total

--- a/README.md
+++ b/README.md
@@ -157,8 +157,12 @@ directories created by `.read`.
 
 #### Errors
 
+Useful debugging information may be shown by setting the `.broccoli` property on
+the generated error with a metadata object.
+
 When it is known which file caused a given error, plugin authors can make errors
-easier to track down by setting the `.file` property on the generated error.
+easier to track down by setting the `.file` property on the metadata object.
+Setting the `.file` property directly on the error object is deprecated.
 
 This `.file` property is used by both the console logging, and the server middleware
 to display more helpful error messages.
@@ -166,7 +170,7 @@ to display more helpful error messages.
 Due to the asynchronous architecture of Broccoli, stack traces may not reflect the
 original source of errors. To prevent this, the stack may be collected at the plugin's
 constructor with `new Error().stack` and then injected into the `.brocfileLocation`
-property on the thrown error object.
+property on the metadata object.
 
 When present, the `.brocfileLocation` property will replace the actual stack trace
 in the console logging.

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,6 +1,7 @@
 var path = require('path')
 var findup = require('findup-sync')
 var Promise = require('rsvp').Promise
+var replaceErrorMessage = require('./error').replaceErrorMessage
 
 
 exports.Builder = Builder
@@ -33,6 +34,11 @@ Builder.prototype.build = function (willReadStringTree) {
       if (typeof err === 'string') {
         err = new Error(err + ' [string exception]')
       }
+      
+      if (err.broccoli && err.broccoli.brocfileLocation) {
+        err.stack = replaceErrorMessage(err.broccoli.brocfileLocation, err.message)
+      }
+      
       throw err
     })
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -43,18 +43,7 @@ function broccoliCLI () {
           process.exit(0)
         })
         .catch(function (err) {
-          // Should show file and line/col if present
-          if (err.file) {
-            console.error('File: ' + err.file)
-          }
-
-          // Show adjusted call stack if present
-          if (err.brocfileLocation) {
-            printBrocfileLocation(err)
-          } else {
-            console.error(err.stack)
-          }
-
+          printErrorInfo(err);
           console.error('\nBuild failed')
           process.exit(1)
         })
@@ -67,10 +56,41 @@ function broccoliCLI () {
   }
 }
 
-function printBrocfileLocation(err) {
-  var stack = err.brocfileLocation
-  stack = stack.replace(/^Error[^\n]+/, 'Error: ' + err.message)
-  console.error(stack)
+function printErrorInfo(err) {
+  var file
+  var brocfileLocation
+
+  // Consider deprecated .file property if present
+  if (err.file) {
+    console.error('error.file is deprecated.\nUse `error.broccoli = { file: ... }` instead.')
+    file = err.file
+  }
+
+  if (err.broccoli) {
+    if (err.broccoli.file) {
+      file = err.broccoli.file
+    }
+
+    if (err.broccoli.brocfileLocation) {
+      brocfileLocation = err.broccoli.brocfileLocation
+    }
+  }
+
+  // Should show file and line/col if present
+  if (file) {
+    console.error('File: ' + file)
+  }
+
+  // Show adjusted call stack if present
+  if (brocfileLocation) {
+    printBrocfileLocation(err.message, brocfileLocation)
+  } else {
+    console.error(err.stack)
+  }
+}
+
+function printBrocfileLocation(message, stack) {
+  console.error(stack.replace(/^Error[^\n]+/, 'Error: ' + message))
 }
 
 function getBuilder () {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,14 +66,8 @@ function printErrorInfo(err) {
     file = err.file
   }
 
-  if (err.broccoli) {
-    if (err.broccoli.file) {
-      file = err.broccoli.file
-    }
-
-    if (err.broccoli.brocfileLocation) {
-      brocfileLocation = err.broccoli.brocfileLocation
-    }
+  if (err.broccoli && err.broccoli.file) {
+    file = err.broccoli.file
   }
 
   // Should show file and line/col if present
@@ -81,16 +75,8 @@ function printErrorInfo(err) {
     console.error('File: ' + file)
   }
 
-  // Show adjusted call stack if present
-  if (brocfileLocation) {
-    printBrocfileLocation(err.message, brocfileLocation)
-  } else {
-    console.error(err.stack)
-  }
-}
-
-function printBrocfileLocation(message, stack) {
-  console.error(stack.replace(/^Error[^\n]+/, 'Error: ' + message))
+  // Show call stack if present
+  console.error(err.stack)
 }
 
 function getBuilder () {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -47,7 +47,14 @@ function broccoliCLI () {
           if (err.file) {
             console.error('File: ' + err.file)
           }
-          console.error(err.stack)
+
+          // Show adjusted call stack if present
+          if (err.brocfileLocation) {
+            printBrocfileLocation(err)
+          } else {
+            console.error(err.stack)
+          }
+
           console.error('\nBuild failed')
           process.exit(1)
         })
@@ -58,6 +65,12 @@ function broccoliCLI () {
     program.outputHelp()
     process.exit(1)
   }
+}
+
+function printBrocfileLocation(err) {
+  var stack = err.brocfileLocation
+  stack = stack.replace(/^Error[^\n]+/, 'Error: ' + err.message)
+  console.error(stack)
 }
 
 function getBuilder () {

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,0 +1,5 @@
+module.exports.replaceErrorMessage = replaceErrorMessage
+
+function replaceErrorMessage(stack, message) {
+  return stack.replace(/^Error[^\n]*/, 'Error: ' + message)
+}


### PR DESCRIPTION
Adds support for a `.brocfileLocation` property on error objects thrown by plugins as suggested by @rwjblue in issue #192.

Setting the property in `broccoli-writer` was not possible as not every plugin calls its parent's constructor (eg: `broccoli-es6-concatenator`), but decorating the error is feasible with a simple:

```javascript
    }).catch(function(err) {
      if (self.brocfileLocation) {
        err.brocfileLocation = self.brocfileLocation
      }
      throw err
    })
``` 