### PR TITLE
Add CORS header

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,5 +1,6 @@
 var path = require('path')
 var fs = require('fs')
+var dns = require('dns')
 
 var handlebars = require('handlebars')
 var url = require('url')
@@ -99,14 +100,26 @@ module.exports = function getMiddleware(watcher, options) {
       response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
       response.setHeader('Content-Length', stat.size)
       response.setHeader('Content-Type', type)
-      // add CORS headers for font files
-      response.setHeader('Access-Control-Allow-Origin', '*')
 
-      // read file sync so we don't hold open the file creating a race with
-      // the builder (Windows does not allow us to delete while the file is open).
-      buffer = fs.readFileSync(filename)
-      response.writeHead(200)
-      response.end(buffer)
+      function writeResponse() {
+        // read file sync so we don't hold open the file creating a race with
+        // the builder (Windows does not allow us to delete while the file is open).
+        buffer = fs.readFileSync(filename)
+        response.writeHead(200)
+        response.end(buffer)
+      }
+
+      if(request.headers.origin) {
+        // Check if origin resolves to a loopback IP, only add CORS headers if that's the case.
+        dns.lookup(url.parse(request.headers.origin).hostname, function(err, address) {
+          if(!err && address === '127.0.0.1') {
+            response.setHeader('Access-Control-Allow-Origin', request.headers.origin)
+            writeResponse()
+          }
+        });
+      } else {
+        writeResponse()
+      }
     }, function(buildError) {
       var context = {
         message: buildError.message || buildError,

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -99,6 +99,8 @@ module.exports = function getMiddleware(watcher, options) {
       response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
       response.setHeader('Content-Length', stat.size)
       response.setHeader('Content-Type', type)
+      // add CORS headers for font files
+      response.setHeader('Access-Control-Allow-Origin', '*')
 
       // read file sync so we don't hold open the file creating a race with
       // the builder (Windows does not allow us to delete while the file is open).


### PR DESCRIPTION
When developing with Broccoli, sometimes one might want to serve up font files from the Broccoli server. However, certain browsers restrict access to font files based on CORS rules. This makes it impossible to have broccoli serve up font files to another application running on a separate port. This simply adds a CORS header which allows access to these files.
