### PR TITLE
dist folder is now default if build folder is omitted.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,9 +21,12 @@ function broccoliCLI () {
       broccoli.server.serve(getBuilder(), options)
     })
 
-  program.command('build <target>')
-    .description('output files to target directory')
+  program.command('build [target]')
+    .description('output files to target directory (Default: dist/)')
     .action(function(outputDir) {
+      if (outputDir === undefined) {
+        outputDir = 'dist'
+      }
       actionPerformed = true
       var builder = getBuilder()
       builder.build()


### PR DESCRIPTION
I quite got to like this from ember-cli.