### PR TITLE
Use the connect-history-api-fallback middleware to redirect 404s to /

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,7 @@ var middleware = require('./middleware')
 var http = require('http')
 var tinylr = require('tiny-lr')
 var connect = require('connect')
+var historyApiFallback = require('connect-history-api-fallback');
 
 exports.serve = serve
 function serve (builder, options) {
@@ -12,7 +13,7 @@ function serve (builder, options) {
 
   var watcher = options.watcher || new Watcher(builder, {verbose: true})
 
-  var app = connect().use(middleware(watcher))
+  var app = connect().use(historyApiFallback).use(middleware(watcher))
 
   var server = http.createServer(app)
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "broccoli-slow-trees": "^1.0.0",
     "commander": "^2.0.0",
     "connect": "^3.2.0",
+    "connect-history-api-fallback": "0.0.5",
     "copy-dereference": "^1.0.0",
     "findup-sync": "^0.1.2",
     "handlebars": "^2.0.0",


### PR DESCRIPTION
This adds a simple connect middleware to the current server implementation to fallback SPA browser reloads to the root path.

I've skimmed through the currently open PRs and issues and it's not clear if it's ever planned to support this in Broccoli. Please let me know if it's a wrong way to go.

P.S. Broccoli rocks. :)