### PR TITLE
Add back npm reference to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ module.exports = pickFiles('app', {
 })
 ```
 
+## Plugins
+
+You can find plugins under the [broccoli-plugin-keyword](https://www.npmjs.org/browse/keyword/broccoli-plugin) on npm.
+
 ### Running Broccoli, Directly or Through Other Tools
 
 * [broccoli-timepiece](https://github.com/rjackson/broccoli-timepiece)


### PR DESCRIPTION
As mentioned in comments at https://github.com/broccolijs/broccoli/commit/fc4b34ebd233c5a55de0754fc851d64bd260e4e2
