### PR TITLE
Fail fast if outputDir already exists, instead of building first

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,6 +24,12 @@ function broccoliCLI () {
   program.command('build <target>')
     .description('output files to target directory')
     .action(function(outputDir) {
+
+      if (fs.existsSync(outputDir)) {
+        console.error('%s/ exists, we cannot build into an existing directory', outputDir);
+        process.exit(1)
+      }
+
       actionPerformed = true
       var builder = getBuilder()
       builder.build()
@@ -32,7 +38,6 @@ function broccoliCLI () {
           try {
             copyDereferenceSync(dir, outputDir)
           } catch (err) {
-            if (err.code === 'EEXIST') err.message += ' (we cannot build into an existing directory)'
             throw err
           }
         })


### PR DESCRIPTION
Fixes #217 