### PR TITLE
Add a force option on build.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var program = require('commander')
 var copyDereferenceSync = require('copy-dereference').sync
-
+var shelljs = require('shelljs')
 var broccoli = require('./index')
 
 module.exports = broccoliCLI
@@ -23,12 +23,16 @@ function broccoliCLI () {
 
   program.command('build <target>')
     .description('output files to target directory')
-    .action(function(outputDir) {
+    .option('-f, --force', 'replace the target directory if it already exists')
+    .action(function(outputDir, options) {
       actionPerformed = true
       var builder = getBuilder()
       builder.build()
         .then(function (hash) {
           var dir = hash.directory
+          if ( options.force && shelljs.test('-d', outputDir) ) {
+            shelljs.rm('-rf', outputDir)
+          }
           try {
             copyDereferenceSync(dir, outputDir)
           } catch (err) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mime": "^1.2.11",
     "promise-map-series": "^0.2.0",
     "rsvp": "^3.0.6",
+    "shelljs": "^0.3.0",
     "tiny-lr": "^0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds a --force (or -f) option on building which will remove the target if it's a pre-existing directory. Hence making the "EEXIST" error avoidable if desired.

Fixes [broccoli-cli issue 4](https://github.com/broccolijs/broccoli-cli/issues/4)

This adds shelljs as a dependency, which is a bit of a strange library - so I understand if you're not keen on it :-) (I'd probably, personally, expect use fs-extra for this task - but don't mind, and shelljs seemed interesting :-) (and is already used by a broccoli dependency :-) )