### PR TITLE
Allow users to pass in their own connect app

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,7 @@ function serve (builder, options) {
 
   var watcher = options.watcher || new Watcher(builder, {verbose: true})
 
-  var app = connect().use(middleware(watcher))
+  var app = (options.app || connect()).use(middleware(watcher))
 
   var server = http.createServer(app)
 


### PR DESCRIPTION
In working on @cabbagejs, it'd be fantastic if we were able to use the broccoli.serve API but also use additional middleware to the top and bottom of the response dispatch stack. In lieu of Broccoli providing anything fancy, simply allowing the user to pass an existing app as a supplied option has been enough for us to get started at implementing our own custom features like API stubbing and API proxying.

I started this as a PR and not an issue only to make the point that a one line change is all it would take to unblock us (short of writing our own server from scratch), but what I'd really like is discussion from @rwjblue  and @joliss about the merits of the idea. For all I know, there may exist a much better existing way to hook into the Broccoli server.

Thank you!! :heart:
