### PR TITLE
Explain `Brocfile.js` better in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,48 @@ npm install --global broccoli-cli
 
 Check out
 [broccoli-sample-app](https://github.com/broccolijs/broccoli-sample-app).
+Or read about how to write a `Brocfile.js` below.
 
 ## Brocfile.js
 
 A `Brocfile.js` file in the project root contains the build specification. It
-should export a tree which may simply be the directory path (as a string). To
-build more advanced output trees you may want to use some of the plugins listed
-below.
+should export a tree.
 
-The following would export the `app/` subdirectory as a tree:
+A tree can be any string representing a directory path, like `'app'` or
+`'src'`. Or a tree can be an object conforming to the [Plugin API
+Specification](#plugin-api-specification). A `Brocfile.js` will usually
+directly work with only directory paths, and then use the plugins in the
+[Plugins](#plugins) section to generate transformed trees.
+
+The following simple `Brocfile.js` would export the `app/` subdirectory as a
+tree:
 
 ```js
 module.exports = 'app'
 ```
 
-Alternatively, the following would export the `app/` subdirectory as `appkit/`:
+With that Brocfile, the build result would equal the contents of the `app`
+tree in your project folder. For example, say your project contains these
+files:
+
+    app
+    ├─ main.js
+    └─ helper.js
+    Brocfile.js
+    package.json
+    …
+
+Running `broccoli build the-output` (a command provided by
+[broccoli-cli](https://github.com/broccolijs/broccoli-cli)) would generate
+the following folder within your project folder:
+
+    the-output
+    ├─ main.js
+    └─ helper.js
+
+### Using plugins in a `Brocfile.js`
+
+The following `Brocfile.js` exports the `app/` subdirectory as `appkit/`:
 
 ```js
 var pickFiles = require('broccoli-static-compiler')
@@ -54,9 +81,28 @@ module.exports = pickFiles('app', {
 })
 ```
 
+That example uses the plugin
+[`broccoli-static-compiler`](https://www.npmjs.com/package/broccoli-static-compiler).
+In order for the `require` call to work, you must first put the plugin in
+your `devDependencies` and install it, with
+
+    npm install --save-dev broccoli-static-compiler
+
+With the above `Brocfile.js` and the file tree from the previous example,
+running `broccoli build the-output` would generate the following folder:
+
+    the-output
+    └─ appkit
+       ├─ main.js
+       └─ helper.js
+
+### A larger example
+
+You can see a full-featured `Brocfile.js` [in `broccoli-sample-app`](https://github.com/broccolijs/broccoli-sample-app/blob/master/Brocfile.js).
+
 ## Plugins
 
-You can find plugins on [broccoliplugins.com](http://broccoliplugins.com) or under the [broccoli-plugin-keyword](https://www.npmjs.org/browse/keyword/broccoli-plugin) on npm.
+You can find plugins on [broccoliplugins.com](http://broccoliplugins.com) or under the [broccoli-plugin keyword](https://www.npmjs.org/browse/keyword/broccoli-plugin) on npm.
 
 ### Running Broccoli, Directly or Through Other Tools
 


### PR DESCRIPTION
This information should help new Broccoli users who want to write or add to a `Brocfile.js`.

I wrote this because it took me a long time to figure out how to write a simple `Brocfile.js` for my non-Ember.js website. Here are the problems with the README that I saw and fixed:

* The Getting Started made it sound like browsing the [broccoli-sample-app](https://github.com/broccolijs/broccoli-sample-app/blob/master/Brocfile.js) would teach you everything you need. Now it mentions that you can read the below Brocfile.js section as well.
* The part about how trees can be strings made it sound like that only applies to the tree you export. Now it should be clear that this works for trees that are transformed within the Brocfile, too.
* I say you will “usually” use plugins, instead of saying you “may want to use” plugins. I would guess that almost all Broccoli users use plugins, instead of writing custom tree transformers.
* I was unsure whether exporting `'app'` would output an `app` folder, or just the files that it contains. The new example directory trees show that it outputs just the files it contains.
* I indicate how to install and use any plugin in a `Brocfile.js`. This helps users like me who are writing their first Node project, and also shows all users that dev dependencies can be required in a Brocfile.
* At the end of the Brocfile.js section, I link directly to the `Brocfile.js` within broccoli-sample-app, to guide readers to the next learning step.
* The link text for “broccoli-plugin keyword” was accidentally “broccoli-plugin-keyword”.

Hopefully, the addition of this information to the README will prevent new users from trying to base their `Brocfile.js` off the one in the [introductory blog post](http://www.solitr.com/blog/2014/02/broccoli-first-release/) linked at the beginning of the README, like I did. That `Brocfile.js` is so out-of-date, reading it does more harm than good.