### PR TITLE
Update slow trees output to include cumulative stats.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/broccolijs/broccoli",
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.2.0",
-    "broccoli-slow-trees": "^1.0.0",
+    "broccoli-slow-trees": "^1.1.0",
     "commander": "^2.0.0",
     "connect": "^3.2.0",
     "copy-dereference": "^1.0.0",


### PR DESCRIPTION
Added in https://github.com/rwjblue/broccoli-slow-trees/pull/3 by @timmfin.