### PR TITLE
Added --no-verbose option to not print slow trees

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,6 +16,7 @@ function broccoliCLI () {
     .option('--port <port>', 'the port to bind to [4200]', 4200)
     .option('--host <host>', 'the host to bind to [localhost]', 'localhost')
     .option('--live-reload-port <port>', 'the port to start LiveReload on [35729]', 35729)
+    .option('--no-verbose', 'use this to not print slow trees')
     .action(function(options) {
       actionPerformed = true
       broccoli.server.serve(getBuilder(), options)

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ function serve (builder, options) {
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
 
-  var watcher = options.watcher || new Watcher(builder, {verbose: true})
+  var watcher = options.watcher || new Watcher(builder, {verbose: options.verbose})
 
   var app = connect().use(middleware(watcher))
 


### PR DESCRIPTION
Hi there,

I added an option to ```broccoli serve``` :
```shell
$ broccoli serve --no-verbose
```

This basically does not print the slow trees when used.

I thought it would be useful to not print slow trees, especially when running other plugins. This option basically removes the verbose from the console, leaving more space for other prints.
In my case I'm running JSHint and the printSlowTrees was showing slow trees in my terminal, I had then to scroll up every time to check the JSHint errors. 

The option was already used [in the Watcher](https://github.com/broccolijs/broccoli/blob/master/lib/watcher.js#L49), I just plugged the cli to it.