### PR TITLE
skipMissingIndex option to prevent responding with dirTemplate on dir url

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -8,8 +8,26 @@ var mime = require('mime')
 var errorTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '../templates/error.html')).toString())
 var dirTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '../templates/dir.html')).toString())
 
+var defaultOptions = {
+  autoIndex: true
+}
+
+function defaults(target, source){
+  // like underscore's _.defaults
+  var out = {}
+  for (key in source) {
+    if (target[key] === undefined) {
+      out[key] = source[key]
+    } else {
+      out[key] = target[key]
+    }
+  }
+  return out
+}
+
 module.exports = function(watcher/* , options */) {
-  var options =  arguments[1] || {};
+  var options = arguments[1] || {};
+  options = defaults(options, defaultOptions)
 
   return function broccoliMiddleware(request, response, next) {
     watcher.then(function(hash) {
@@ -49,7 +67,7 @@ module.exports = function(watcher/* , options */) {
         // if folder doesn't contain an index.html file,
         // browse the folder
         if (!fs.existsSync(filename + 'index.html')) {
-          if (options.skipMissingIndex) {
+          if (!options.autoIndex) {
             next()
             return
           }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -49,6 +49,10 @@ module.exports = function(watcher/* , options */) {
         // if folder doesn't contain an index.html file,
         // browse the folder
         if (!fs.existsSync(filename + 'index.html')) {
+          if (options.skipMissingIndex) {
+            next()
+            return
+          }
           response.writeHead(200)
           response.end(dirTemplate({
             url: request.url,


### PR DESCRIPTION
The use case here is not so much for security (see [here](https://github.com/broccolijs/broccoli/issues/7#issuecomment-32134001)), but to prevent rendering an asset dir when it would conflict with another url. Consider an express app:
```
app.use(broccoliMiddleware);
app.use(sessionMiddleware); // some small middleware that takes non-zero time on each request
app.get('/', function(){ ... });
```
 If we put broccoli first, broccoli will claim the `/` route. If we specify broccoli middleware last, then broccoli will be subject to session middleware, an unnecessary slowdown.