### PR TITLE
Emit a event to notify that a build is starting.

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -10,6 +10,11 @@ function Watcher(builder, options) {
   this.options = options || {}
   this.watchedDirs = {}
 
+  // notify the first build once the object is returned
+  process.nextTick(function(){
+    this.emit('start')
+  }.bind(this))
+
   this.check()
 }
 

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -44,6 +44,7 @@ Watcher.prototype.check = function() {
 
     if (Object.keys(this.watchedDirs).length === 0 || changedDirs.length > 0) {
       this.watchedDirs = {}
+      this.emit('start', changedDirs)
       this.current = this.builder.build(this.addWatchDir.bind(this))
       this.current.then(function(hash) {
         if (this.options.verbose) {


### PR DESCRIPTION
Hi.

In my fork of broccoli-timepiece (https://github.com/ShogunPanda/broccoli-timepiece) I'm trying to add a file based synchronization mechanism.

My use case is that I run broccoli-timepiece (but this could also apply to `broccoli-cli serve`) in a terminal.
When I go back to Rails I'd like to see a Rails assets pipeline like behavior:

1. The Rails process should not render assets if a build is in progress.
2. The Rails process should show a error template in case of errors.

I already solved the latter by creating a JSON dump in the `error` event and by deleting it in the `change` event.

In this PR I added a `start` event to the Watcher so that I (well, everyone) can be notified when a build starts. The way I'm gonna use it to create a temporary file in the `start` that will be deleted in both the `change` and `error` event.

Let me know if there is a better way to achieve this.
Hope you're gonna like it!
  Paolo