### PR TITLE
Add --verbose CLI flag

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,7 +15,7 @@ function broccoliCLI () {
     .description('start a broccoli server')
     .option('--port <port>', 'the port to bind to [4200]', 4200)
     .option('--host <host>', 'the host to bind to [localhost]', 'localhost')
-    .option('--verbose', 'enable verbose output', false)
+    .option('--verbose', 'enable verbose output')
     .action(function(options) {
       actionPerformed = true
       broccoli.server.serve(getBuilder(), options)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,6 +15,7 @@ function broccoliCLI () {
     .description('start a broccoli server')
     .option('--port <port>', 'the port to bind to [4200]', 4200)
     .option('--host <host>', 'the host to bind to [localhost]', 'localhost')
+    .option('--verbose', 'enable verbose output', false)
     .action(function(options) {
       actionPerformed = true
       broccoli.server.serve(getBuilder(), options)

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,7 +9,7 @@ function serve (builder, options) {
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
 
-  var watcher = options.watcher || new Watcher(builder, {verbose: true})
+  var watcher = options.watcher || new Watcher(builder, {verbose: options.verbose})
 
   var app = connect().use(middleware(watcher))
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,7 +9,7 @@ function serve (builder, options) {
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
 
-  var watcher = options.watcher || new Watcher(builder, {verbose: options.verbose})
+  var watcher = options.watcher || new Watcher(builder, {verbose: !!options.verbose})
 
   var app = connect().use(middleware(watcher))
 


### PR DESCRIPTION
I added a `--verbose` command line flag to enable verbose output (which currently just prints the slowest trees). It does not seem like the verbose mode should be the default behaviour (as it is now).
