### PR TITLE
Return a server POJO to allow for easier wrappers on Broccoli Server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -6,14 +6,15 @@ var connect = require('connect')
 exports.serve = serve
 function serve (builder, options) {
   options = options || {}
+  var server = {}
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
 
-  var watcher = options.watcher || new Watcher(builder, {verbose: true})
+  var server.watcher = options.watcher || new Watcher(builder, {verbose: true})
 
-  var app = connect().use(middleware(watcher))
+  var server.app = connect().use(middleware(server.watcher))
 
-  var server = http.createServer(app)
+  var server.http = http.createServer(server.app)
 
   // We register these so the 'exit' handler removing temp dirs is called
   function cleanupAndExit() {
@@ -28,11 +29,11 @@ function serve (builder, options) {
   process.on('SIGINT', cleanupAndExit)
   process.on('SIGTERM', cleanupAndExit)
 
-  watcher.on('change', function(results) {
+  server.watcher.on('change', function(results) {
     console.log('Built - ' + Math.round(results.totalTime / 1e6) + ' ms @ ' + new Date().toString())
   })
 
-  watcher.on('error', function(err) {
+  server.watcher.on('error', function(err) {
     console.log('Built with error:')
     // Should also show file and line/col if present; see cli.js
     if (err.file) {
@@ -42,5 +43,6 @@ function serve (builder, options) {
     console.log('')
   })
 
-  server.listen(parseInt(options.port, 10), options.host)
+  server.http.listen(parseInt(options.port, 10), options.host)
+  return server
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,11 +10,11 @@ function serve (builder, options) {
 
   console.log('Serving on http://' + options.host + ':' + options.port + '\n')
 
-  var server.watcher = options.watcher || new Watcher(builder, {verbose: true})
+  server.watcher = options.watcher || new Watcher(builder, {verbose: true})
 
-  var server.app = connect().use(middleware(server.watcher))
+  server.app = connect().use(middleware(server.watcher))
 
-  var server.http = http.createServer(server.app)
+  server.http = http.createServer(server.app)
 
   // We register these so the 'exit' handler removing temp dirs is called
   function cleanupAndExit() {


### PR DESCRIPTION
Returning a POJO with a few properties allows developers to more easily chain things on top of the existing broccoli asset server.

Without this, developers would have to basically recreate all of this functionality in order to just do something as simple as adding livereload back to the existing server (which can now be done with just a few LOC):

```
function getBuilder () {
  var tree = broccoli.loadBrocfile();
  return new broccoli.Builder(tree);
};

var server = broccoli.server.serve(getBuilder(), {port: 4200, host: 'localhost'});

var livereloadServer = new tinylr.Server;
livereloadServer.listen(35729, function (err) {
  if(err) {
    throw err;
  }
});

var liveReload = function() {
  // Chrome LiveReload doesn't seem to care about the specific files as long
  // as we pass something.
  livereloadServer.changed({body: {files: ['livereload_dummy']}});
};

server.watcher.on('change', function(results) {
  liveReload();
});
```

Similarly, devs could wrap and add things like middleware for form submitting to make small servers with asset builds to test and try things out on.

This exposes a few different properties from a `server` POJO:

* `watcher` - the Broccoli watcher instance for the current server
* `app` - the connect app instance
* `http` - the raw http server running everything under the hood

This does not change or damage any existing APIs since nothing was ever returned by `broccoli.server.serve`.