### PR TITLE
hooks to enable outside monitoring

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -31,18 +31,24 @@ function summarize(node) {
   }
 }
 
+RSVP.EventTarget.mixin(Builder.prototype);
+
 Builder.prototype.build = function (willReadStringTree) {
   var builder = this
 
   var newTreesRead = []
   var nodeCache = []
 
+  builder.trigger('start');
   return RSVP.Promise.resolve()
     .then(function () {
       return readAndReturnNodeFor(builder.tree) // call builder.tree.read()
     })
     .then(summarize)
     .finally(appendNewTreesRead)
+    .finally(function() {
+      builder.trigger('end');
+    })
     .catch(wrapStringErrors);
 
 
@@ -72,6 +78,8 @@ Builder.prototype.build = function (willReadStringTree) {
     }
 
     var node = new Node(tree)
+
+   builder.trigger('nodeStart', node);
 
     // we don't actually support duplicate trees, as such we should likely tag them..
     // and kill the parallel array structure
@@ -135,6 +143,7 @@ Builder.prototype.build = function (willReadStringTree) {
 
     return treeDirPromise
       .then(function (treeDir) {
+        builder.trigger('nodeEnd', node);
         if (treeDir == null) throw new Error(tree + ': .read must return a directory')
         node.directory = treeDir
         return node


### PR DESCRIPTION
lets me do stuff like:

```js
this.builder = new broccoli.Builder(this.tree);

var builder = this;

this.builder.on('start', function(node) {
  builder.monitor = new FSMonitor();
});

this.builder.on('nodeStart', function(node) {
  var metric = new NodeMetric(node);
  builder.monitor.push(metric);
});

this.builder.on('nodeEnd', function(node) {
  builder.monitor.pop();
});

this.builder.on('end', function(node) {
  console.log('endBuild');
  console.log(builder.monitor.totalStats());
});
```

which ultimately results in: https://gist.github.com/stefanpenner/1c319a44a30efd0071fc