### PR TITLE
Fix Snyk vulnerabilty report errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "connect": "^3.3.3",
     "copy-dereference": "^1.0.0",
     "findup-sync": "^0.2.1",
-    "handlebars": "^3.0.1",
+    "handlebars": "^4.0.4",
     "mime": "^1.2.11",
     "rimraf": "^2.4.3",
     "rsvp": "^3.0.17",


### PR DESCRIPTION
```bash
$ snyk test broccoli@v1.0.0-beta.5
✗ Vulnerability found on uglify-js@2.3.6
Info: https://app.snyk.io/vuln/npm:uglify-js:20150824
From: broccoli@1.0.0-beta.5 > handlebars@^3.0.1 > uglify-js@~2.3
Upgrade direct dependency handlebars@^3.0.1 to handlebars@4.0.0 (triggers upgrades to uglify-js@2.4.24)

Tested broccoli@v1.0.0-beta.5 for known vulnerabilities, found 1 vulnerability.
```

https://app.snyk.io/package/npm/broccoli