### PR TITLE
Remove reference to lapsed domain broccoliplugins.com from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can see a full-featured `Brocfile.js` in
 
 ## Plugins
 
-You can find plugins on [broccoliplugins.com](http://broccoliplugins.com) or under the [broccoli-plugin keyword](https://www.npmjs.org/browse/keyword/broccoli-plugin) on npm.
+You can find plugins under the [broccoli-plugin keyword](https://www.npmjs.org/browse/keyword/broccoli-plugin) on npm.
 
 ### Running Broccoli, Directly or Through Other Tools
 


### PR DESCRIPTION
Unless someone plans to renew broccoliplugins.com, it shouldn't be referenced in the README. @pootsbook 
