### PR TITLE
Enable enhanced customization of server options

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,7 @@
 var fs = require('fs')
 var program = require('commander')
 var copyDereferenceSync = require('copy-dereference').sync
+var findup = require('findup-sync')
 
 var broccoli = require('./index')
 
@@ -17,6 +18,7 @@ function broccoliCLI () {
     .option('--host <host>', 'the host to bind to [localhost]', 'localhost')
     .action(function(options) {
       actionPerformed = true
+      mergeStaticOptions(options);
       broccoli.server.serve(getBuilder(), options)
     })
 
@@ -60,4 +62,38 @@ function broccoliCLI () {
 function getBuilder () {
   var node = broccoli.loadBrocfile()
   return new broccoli.Builder(node)
+}
+
+/**
+ * Merges command line options with any options included within
+ * a JSON-formatted `.broccoli` file located in the project's
+ * root directory
+ * 
+ * @param   {Object}  options The options passed via the CLI
+ * @param   {String}  [cwd]   The current working directory to locate the `.broccoli` file
+ * @return  {Object} The merged CLI and static options
+ */
+function mergeStaticOptions(options, cwd) {
+  cwd = cwd || process.cwd();
+  options = options || {};
+
+  var brocOptionsfile = findup('.broccoli', {cwd: cwd});
+
+  if (fs.existsSync(brocOptionsfile)) {
+    var staticOptions = parseJsonFile(brocOptionsfile);
+    options = Object.assign( options, staticOptions );
+  }
+
+  return options;
+}
+
+broccoliCLI.mergeStaticOptions = mergeStaticOptions
+
+function parseJsonFile(filePath) {
+  var contents = fs.readFileSync(filePath, 'utf8').toString()
+  return JSON.parse( stripComments(contents) )
+}
+
+function stripComments(str) {
+  return str.replace(/(?:\/\*(?:[\s\S]*?)\*\/)|(?:([\s;])+\/\/(?:.*)$)/gm, '').trim()
 }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -75,7 +75,7 @@ module.exports = function getMiddleware(watcher, options) {
             }),
             liveReloadPath: options.liveReloadPath
           }
-          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
+          setHeaders(response, options.headers, {'Cache-Control': 'private, max-age=0, must-revalidate'})
           response.writeHead(200)
           response.end(dirTemplate(context))
           return
@@ -100,9 +100,11 @@ module.exports = function getMiddleware(watcher, options) {
       if (charset) {
         type += '; charset=' + charset
       }
-      response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
-      response.setHeader('Content-Length', stat.size)
-      response.setHeader('Content-Type', type)
+      setHeaders(response, options.headers, {
+        'Cache-Control': 'private, max-age=0, must-revalidate',
+        'Content-Length': stat.size,
+        'Content-Type': type
+      })
 
       // read file sync so we don't hold open the file creating a race with
       // the builder (Windows does not allow us to delete while the file is open).
@@ -122,4 +124,11 @@ module.exports = function getMiddleware(watcher, options) {
       response.end(errorTemplate(context))
     }).catch(function(err) { console.log(err.stack) })
   }
+}
+
+function setHeaders(response, userHeaders, defaultHeaders) {
+  var headers = Object.assign({}, defaultHeaders, userHeaders)
+  Object.keys(headers).forEach(function(header) {
+    response.setHeader(header, headers[header]);
+  })
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,11 +9,13 @@ function serve (builder, options) {
   options = options || {}
   var server = {}
 
-  console.log('Serving on http://' + options.host + ':' + options.port + '\n')
+  if (! options.disableLogging) {
+    console.log('Serving on http://' + options.host + ':' + options.port + '\n')
+  }
 
   server.watcher = options.watcher || new Watcher(builder)
 
-  server.app = connect().use(middleware(server.watcher))
+  server.app = connect().use(middleware(server.watcher, options))
 
   server.http = http.createServer(server.app)
 
@@ -41,10 +43,12 @@ function serve (builder, options) {
   process.on('SIGINT', cleanupAndExit)
   process.on('SIGTERM', cleanupAndExit)
 
-  server.watcher.on('change', function() {
-    printSlowNodes(builder.outputNodeWrapper)
-    console.log('Built - ' + Math.round(builder.outputNodeWrapper.buildState.totalTime) + ' ms @ ' + new Date().toString())
-  })
+  if (! options.disableLogging) {
+    server.watcher.on('change', function() {
+      printSlowNodes(builder.outputNodeWrapper)
+      console.log('Built - ' + Math.round(builder.outputNodeWrapper.buildState.totalTime) + ' ms @ ' + new Date().toString())
+    })
+  }
 
   server.watcher.on('error', function(err) {
     console.log('Built with error:')

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "multidep": "^2.0.0",
     "sinon": "^1.17.1",
     "sinon-chai": "^2.8.0",
+    "supertest": "^1.1.0",
     "symlink-or-copy": "^1.0.1"
   },
   "engines": {

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -1,0 +1,117 @@
+var request   = require('supertest');
+var chai      = require('chai');
+var expect    = chai.expect;
+var fs        = require('fs');
+var path      = require('path');
+var tmp       = require('tmp');
+var broccoli  = require('..');
+
+
+var tmpdir, tmpRemoveCallback, defaultOptions;
+
+describe('Options Customization', function() {
+  
+  beforeEach(function() {
+    var tmpObj = tmp.dirSync({ prefix: 'broccoli_static_options_test-', unsafeCleanup: true });
+    tmpdir = tmpObj.name;
+    tmpRemoveCallback = tmpObj.removeCallback;
+    defaultOptions = {port: 4200, host: 'localhost', disableLogging: true};
+  });
+
+  afterEach(function() {
+    tmpRemoveCallback()
+  });
+
+
+  describe('setting options with .broccoli file', function() {
+
+    it('uses default options when .broccoli file is omitted', function() {
+      var options = broccoli.cli.mergeStaticOptions(defaultOptions, tmpdir);
+      expect(options.port).to.be.equal(4200);
+    });
+
+    it('uses .broccoli file options when provided', function() {
+      
+      createStaticOptions({port: 12345});
+      
+      var options = broccoli.cli.mergeStaticOptions(defaultOptions, tmpdir);
+      expect(options.port).to.be.equal(12345);
+      expect(options.host).to.be.equal('localhost');
+    });
+  });
+
+  describe('customizing http headers', function() {
+
+    var node = path.join(process.cwd(), 'test/fixtures/basic');
+    var builder = new broccoli.Builder(node);
+
+    it('uses default options when option.headers is omitted', function() {
+
+      var server = broccoli.server.serve(builder, defaultOptions);
+
+      request(server.app)
+        .get('/foo.txt')
+        .expect('OK')
+        .expect('Cache-Control', 'private, max-age=0, must-revalidate')
+        .expect('Content-Type', /text\/plain/)
+        .expect('Content-Length', '2')
+        .end(function(err, res){
+          if (err) throw err;
+        });
+    });
+
+    it('can add to default headers', function() {
+      createStaticOptions({headers: {
+        'Access-Control-Allow-Origin': '*',
+        'X-Powered-By': 'Broccoli'
+      }});
+
+      var options = broccoli.cli.mergeStaticOptions(defaultOptions, tmpdir);
+      var server = broccoli.server.serve(builder, options);
+
+      request(server.app)
+        .get('/foo.txt')
+        // default response values:
+        .expect('OK')
+        .expect('Cache-Control', 'private, max-age=0, must-revalidate')
+        .expect('Content-Type', /text\/plain/)
+        .expect('Content-Length', '2')
+        // customized response values:
+        .expect('Access-Control-Allow-Origin', '*')
+        .expect('X-Powered-By', 'Broccoli')
+        .end(function(err, res){
+          if (err) throw err;
+        });
+    });
+
+    it('can override default headers', function() {
+      createStaticOptions({headers: {
+        'Cache-Control': 'public, max-age=3600, must-revalidate',
+        'Access-Control-Allow-Origin': '*'
+      }});
+
+      var options = broccoli.cli.mergeStaticOptions(defaultOptions, tmpdir);
+      var server = broccoli.server.serve(builder, options);
+
+      request(server.app)
+        .get('/foo.txt')
+        // default response values:
+        .expect('OK')
+        .expect('Content-Type', /text\/plain/)
+        .expect('Content-Length', '2')
+        // customized response values:
+        .expect('Cache-Control', 'public, max-age=3600, must-revalidate') 
+        .expect('Access-Control-Allow-Origin', '*')
+
+        .end(function(err, res){
+          if (err) throw err;
+        });
+    });
+
+  });
+
+});
+
+function createStaticOptions(options) {
+  fs.writeFileSync(tmpdir + '/.broccoli', JSON.stringify(options), 'utf8')
+}


### PR DESCRIPTION
This pull request aims to enhance the user's ability to customize the options passed to `broccoli.server.serve()` in a couple different ways.

First, users can customize the http response headers created within `lib/middleware.js` by including a `headers` property in the main options object passed in `broccoli.server.serve(builder, options)`.  For example, the following options would enable Broccoli to include a CORS header when serving files on `http://localhost:4200`:

```js
var options = {
  headers: {
    'Access-Control-Allow-Origin': '*'
  }
};

broccoli.server.serve(builder, options);
```

To allow advanced options like these to be easier configure when using Broccoli CLI, this pull request also expands on `lib/cli.js` by allowing users to define an optional `.broccoli` JSON-formatted file within the root directory of their projects.  Any configurations defined within that `.broccoli` file will be pulled whenever calling `broccoli serve`.  For example, the following `.broccoli` file would cause Broccoli to serve on port 12345 with a CORS header:

```js
//  `.broccoli` file saved in project root
{
  "headers": {
    "Access-Control-Allow-Origin": "*"
  },
  "port": 12345
}
```

This pull request includes 5 new passing tests in `test/options_test.js`.  To help clean up the console output when running Mocha, there is new option defined called `disableLogging` which (when set to `true`) will cause `lib/server.js` to *not* call `console.log()` while the Mocha tests are running.