### PR TITLE
add support for serving via ssl

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,6 +15,7 @@ function broccoliCLI () {
     .description('start a broccoli server')
     .option('--port <port>', 'the port to bind to [4200]', 4200)
     .option('--host <host>', 'the host to bind to [localhost]', 'localhost')
+    .option('--ssl', 'serve via https')
     .action(function(options) {
       actionPerformed = true
       broccoli.server.serve(getBuilder(), options)

--- a/lib/server.js
+++ b/lib/server.js
@@ -21,7 +21,7 @@ function serve (builder, options) {
     try {
       sslOptions = {
         key: fs.readFileSync(path.join(process.cwd(), 'ssl/server.key')),
-        cert: fs.readFileSync(path.join(process.cwd(), 'ssl/server.crt')),
+        cert: fs.readFileSync(path.join(process.cwd(), 'ssl/server.crt'))
       }
     } catch(e) {
       throw new Error('SSL key and certificate files must be located at ssl/server.key and ssl/server.crt')

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,9 @@
 var Watcher = require('./watcher')
 var middleware = require('./middleware')
 var http = require('http')
+var https = require('https')
+var fs = require('fs')
+var path = require('path')
 var connect = require('connect')
 var printSlowNodes = require('broccoli-slow-trees')
 
@@ -9,13 +12,25 @@ function serve (builder, options) {
   options = options || {}
   var server = {}
 
-  console.log('Serving on http://' + options.host + ':' + options.port + '\n')
-
   server.watcher = options.watcher || new Watcher(builder)
 
   server.app = connect().use(middleware(server.watcher))
 
-  server.http = http.createServer(server.app)
+  if (options.ssl) {
+    var sslOptions
+    try {
+      sslOptions = {
+        key: fs.readFileSync(path.join(process.cwd(), 'ssl/server.key')),
+        cert: fs.readFileSync(path.join(process.cwd(), 'ssl/server.crt')),
+      }
+    } catch(e) {
+      throw new Error('SSL key and certificate files must be located at ssl/server.key and ssl/server.crt')
+    }
+
+    server.server = https.createServer(sslOptions, server.app)
+  } else {
+    server.server = http.createServer(server.app)  
+  }
 
   server.watcher.watch()
     .catch(function(err) {
@@ -23,7 +38,7 @@ function serve (builder, options) {
     })
     .finally(function() {
       builder.cleanup()
-      server.http.close()
+      server.server.close()
     })
     .catch(function(err) {
       console.log('Cleanup error:')
@@ -56,6 +71,8 @@ function serve (builder, options) {
     console.log('')
   })
 
-  server.http.listen(parseInt(options.port, 10), options.host)
+  server.server.listen(parseInt(options.port, 10), options.host, function() {
+    console.log('Serving on http' + (options.ssl ? 's' : '') + '://' + options.host + ':' + options.port + '\n')    
+  })
   return server
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "copy-dereference": "^1.0.0",
     "findup-sync": "^0.2.1",
     "handlebars": "^4.0.4",
+    "https": "^1.0.0",
     "mime": "^1.2.11",
     "rimraf": "^2.4.3",
     "rsvp": "^3.0.17",


### PR DESCRIPTION
Allows users to run server using SSL via `broccoli serve -ssl`.

SSL key and certificate files must be located in the user's project root at `ssl/server.key` and `ssl/server.crt`.
