### PR TITLE
Specifying a custom port via cli fails with Error

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,7 +7,7 @@ var Watcher = require('./watcher')
 
 
 module.exports = broccoliCLI
-function broccoliCLI () {
+function broccoliCLI (args) {
   var actionPerformed = false
   program
     .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
@@ -52,11 +52,11 @@ function broccoliCLI () {
         })
     })
 
-  program.parse(process.argv)
+  program.parse(args || process.argv)
   if(!actionPerformed) {
     program.outputHelp()
     process.exit(1)
-  }
+  } 
 }
 
 function getBuilder () {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,7 +19,7 @@ function broccoliCLI (args) {
     .option('--host <host>', 'the host to bind to [localhost]', 'localhost')
     .action(function(options) {
       actionPerformed = true
-      broccoli.server.serve(new Watcher(getBuilder()), options.host, options.port)
+      broccoli.server.serve(new Watcher(getBuilder()), options.host, parseInt(options.port))
     })
 
   program.command('build <target>')

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,7 +7,7 @@ exports.serve = serve
 function serve (watcher, host, port) {
   if (watcher.constructor.name !== 'Watcher') throw new Error('Expected Watcher instance')
   if (typeof host !== 'string') throw new Error('Expected host to bind to (e.g. "localhost")')
-  if (typeof port !== 'number') throw new Error('Expected port to bind to (e.g. 4200)')
+  if (typeof port !== 'number' || port !== port) throw new Error('Expected port to bind to (e.g. 4200)')
 
   var server = {}
 

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+var cli = require('../lib/cli')
+var broccoli = require('../lib/index')
+var chai = require('chai')
+var sinon = require('sinon')
+var sinonChai = require('sinon-chai')
+chai.use(sinonChai)
+
+describe('cli', function() {
+    var mock = null
+    beforeEach(function() {
+        cli = require('../lib/cli')
+        mock = sinon.mock(broccoli.server)
+        sinon.stub(broccoli, 'loadBrocfile', function() {
+            return new broccoli.Builder('test/fixtures')
+        })
+        sinon.stub(broccoli, 'Builder', function() {
+            return { watchedPaths: [], build: function() { return new global.Promise(function() {}) }, cleanup: function() {} }
+        })
+    })
+
+    afterEach(function() {
+        mock.restore()
+        broccoli.loadBrocfile.restore()
+        broccoli.Builder.restore()
+        delete require.cache[require.resolve('commander')]
+        delete require.cache[require.resolve('../lib/cli')]
+    })
+
+    it('should start a server with default values', function() {
+        mock.expects('serve').once().withArgs(sinon.match.any, sinon.match.string, sinon.match.number)
+        cli(['node', 'broccoli', 'serve'])
+        mock.verify()
+    })
+
+    it('starts server with given ip adress', function() {
+        mock.expects('serve').withArgs(sinon.match.any, '192.168.2.123', sinon.match.number)
+        cli(['node', 'broccoli', 'serve', '--host', '192.168.2.123'])
+        mock.verify()
+    })
+
+    it('converts port to a number and starts the server at given port', function() {
+        mock.expects('serve').once().withArgs(sinon.match.any, sinon.match.string, 1234)
+        cli(['node', 'broccoli', 'serve', '--port', '1234'])
+        mock.verify()
+    })
+
+    it('converts port to a number and starts the server at given port and host', function() {
+        mock.expects('serve').once().withArgs(sinon.match.any, '192.168.2.123', 1234)
+        cli(['node', 'broccoli', 'serve', '--port=1234', '--host=192.168.2.123'])
+        mock.verify()
+    })
+})

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+var server = require('../lib/server')
+var Watcher = require('../lib/watcher')
+var expect = require('chai').expect
+
+describe('server', function() {
+    it('throws if first argument is not an instance of Watcher', function() {
+        expect(function() {
+            server.serve({}, 123, 1234)
+        }).to.throw(/Watcher/)
+    })
+    it('throws if host is not a string', function() {
+        expect(function() {
+            server.serve(new Watcher(), 123, 1234)
+        }).to.throw(/host/)
+    })
+    it('throws if port is not a number', function() {
+        expect(function() {
+            server.serve(new Watcher(), '0.0.0.0', '1234')
+        }).to.throw(/port/)
+    })
+    it('throws if port is NaN', function() {
+        expect(function() {
+            server.serve(new Watcher(), '0.0.0.0', parseInt('port'))
+        }).to.throw(/port/)
+    })
+})


### PR DESCRIPTION
**Fixes #315**

**Solution**
Converted the port to a number using _parseInt_ and added tests for the cli parameters host and port. Type conversion may cause port to become NaN, so i added another check to server.serve and a few more tests.

**Bug**
Starting broccoli using the cli with the argument --port and a valid port number fails, because port is a string, but server.serve only accepts numbers.

```
> broccoli serve --host=0.0.0.0 --port=8000

C:\...\broccoli\lib\server.js:11
    if (typeof port !== 'number' || port !== port) throw new Error('Expected port to bind to (e.g. 4200)')
                                                   ^

Error: Expected port to bind to (e.g. 4200)
    at Object.serve (C:\cygwin64\home\Stefan\stfsy.github.io\node_modules\broccoli\lib\server.js:11:58)
    at Command.<anonymous> (C:\cygwin64\home\Stefan\stfsy.github.io\node_modules\broccoli\lib\cli.js:23:29)
    at Command.listener (C:\cygwin64\home\Stefan\stfsy.github.io\node_modules\commander\index.js:301:8)
    at emitTwo (events.js:106:13)
    at Command.emit (events.js:191:7)
    at Command.parseArgs (C:\cygwin64\home\Stefan\stfsy.github.io\node_modules\commander\index.js:615:12)
    at Command.parse (C:\cygwin64\home\Stefan\stfsy.github.io\node_modules\commander\index.js:458:21)
    at Object.broccoliCLI [as cli] (C:\cygwin64\home\Stefan\stfsy.github.io\node_modules\broccoli\lib\cli.js:56:13)
    at Object.<anonymous> (C:\cygwin64\home\Stefan\stfsy.github.io\node_modules\broccoli-cli\bin\broccoli:20:10)
    at Module._compile (module.js:541:32)
```

