### PR TITLE
Cli option --watch

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,7 +4,6 @@ const TreeSync = require('tree-sync');
 const fs = require('fs');
 
 const broccoli = require('./index');
-const Watcher = require('./watcher');
 
 module.exports = function broccoliCLI(args) {
   // always require a fresh commander, as it keeps state at module scope
@@ -25,8 +24,11 @@ module.exports = function broccoliCLI(args) {
     .option('--host <host>', 'the host to bind to [localhost]', 'localhost')
     .option('--brocfile-path <path>', 'the path to brocfile')
     .option('--output-path <path>', 'the path to target output folder')
+    .option('--no-watch', 'turn off the watcher')
     .action(options => {
       actionPerformed = true;
+
+      const Watcher = options.watch ? broccoli.Watcher : broccoli.DummyWatcher;
 
       const outputDir = options.outputPath;
       const builder = getBuilder({ brocfilePath: options.brocfilePath });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,7 +27,7 @@ module.exports = function broccoliCLI(args) {
     .option('--output-path <path>', 'the path to target output folder')
     .option('--no-watch', 'turn off the watcher')
     .action(options => {
-      const Watcher = options.watch ? broccoli.Watcher : broccoli.DummyWatcher;
+      const Watcher = getWatcher(options.watch);
       const outputDir = options.outputPath;
       const builder = getBuilder({ brocfilePath: options.brocfilePath });
       const watcher = new Watcher(builder);
@@ -52,7 +52,7 @@ module.exports = function broccoliCLI(args) {
     .option('--output-path <path>', 'the path to target output folder')
     .option('--watch', 'turn on the watcher')
     .action((outputDir, options) => {
-      const Watcher = options.watch ? broccoli.Watcher : broccoli.DummyWatcher;
+      const Watcher = getWatcher(options.watch);
 
       if (outputDir && options.outputPath) {
         console.error('option --output-path and [target] cannot be passed at same time');
@@ -115,6 +115,10 @@ function getBuilder(options) {
     options = {};
   }
   return new broccoli.Builder(broccoli.loadBrocfile(options.brocfilePath));
+}
+
+function getWatcher(isWatching) {
+  return isWatching ? broccoli.Watcher : require('./dummy-watcher');
 }
 
 function guardOutputDir(outputDir) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,16 +1,17 @@
 'use strict';
 
+const RSVP = require('rsvp');
 const TreeSync = require('tree-sync');
 const fs = require('fs');
 
 const broccoli = require('./index');
+const messages = require('./messages');
 
 module.exports = function broccoliCLI(args) {
   // always require a fresh commander, as it keeps state at module scope
   delete require.cache[require.resolve('commander')];
   const program = require('commander');
-
-  let actionPerformed = false;
+  let actionPromise;
 
   program
     .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
@@ -26,10 +27,7 @@ module.exports = function broccoliCLI(args) {
     .option('--output-path <path>', 'the path to target output folder')
     .option('--no-watch', 'turn off the watcher')
     .action(options => {
-      actionPerformed = true;
-
       const Watcher = options.watch ? broccoli.Watcher : broccoli.DummyWatcher;
-
       const outputDir = options.outputPath;
       const builder = getBuilder({ brocfilePath: options.brocfilePath });
       const watcher = new Watcher(builder);
@@ -43,7 +41,8 @@ module.exports = function broccoliCLI(args) {
         });
       }
 
-      broccoli.server.serve(watcher, options.host, parseInt(options.port, 10));
+      const server = broccoli.server.serve(watcher, options.host, parseInt(options.port, 10));
+      actionPromise = (server && server.closingPromise) || RSVP.resolve();
     });
 
   program
@@ -51,8 +50,9 @@ module.exports = function broccoliCLI(args) {
     .description('output files to target directory')
     .option('--brocfile-path <path>', 'the path to brocfile')
     .option('--output-path <path>', 'the path to target output folder')
+    .option('--watch', 'turn on the watcher')
     .action((outputDir, options) => {
-      actionPerformed = true;
+      const Watcher = options.watch ? broccoli.Watcher : broccoli.DummyWatcher;
 
       if (outputDir && options.outputPath) {
         console.error('option --output-path and [target] cannot be passed at same time');
@@ -67,29 +67,47 @@ module.exports = function broccoliCLI(args) {
 
       const builder = getBuilder({ brocfilePath: options.brocfilePath });
       const outputTree = new TreeSync(builder.outputPath, outputDir);
+      const watcher = new Watcher(builder);
 
-      builder
-        .build()
-        .then(() => outputTree.sync())
-        .finally(() => builder.cleanup())
-        .then(() => process.exit(0))
+      watcher.on('buildSuccess', () => {
+        outputTree.sync();
+        messages.onBuildSuccess(builder);
+
+        if (!options.watch) {
+          watcher.quit();
+        }
+      });
+      watcher.on('buildFailure', messages.onBuildFailure);
+
+      function cleanupAndExit() {
+        return watcher.quit();
+      }
+
+      process.on('SIGINT', cleanupAndExit);
+      process.on('SIGTERM', cleanupAndExit);
+
+      actionPromise = watcher
+        .start()
+        .catch(err => console.log((err && err.stack) || err))
+        .finally(() => {
+          builder.cleanup();
+          process.exit(0);
+        })
         .catch(err => {
-          // Should show file and line/col if present
-          if (err.file) {
-            console.error('File: ' + err.file);
-          }
-          console.error(err.stack);
-          console.error('\nBuild failed');
+          console.log('Cleanup error:');
+          console.log((err && err.stack) || err);
           process.exit(1);
         });
     });
 
   program.parse(args || process.argv);
 
-  if (!actionPerformed) {
+  if (!actionPromise) {
     program.outputHelp();
     process.exit(1);
   }
+
+  return actionPromise || RSVP.resolve();
 };
 
 function getBuilder(options) {

--- a/lib/dummy-watcher.js
+++ b/lib/dummy-watcher.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const RSVP = require('rsvp');
+
+class Watcher {
+  constructor(builder) {
+    this.builder = builder;
+    this.currentBuild = null;
+    this._lifetimeDeferred = null;
+  }
+
+  start() {
+    this._lifetimeDeferred = RSVP.defer();
+    this.currentBuild = this.builder.build();
+    this.currentBuild
+      .then(() => this.trigger('buildSuccess'))
+      .catch(err => this.trigger('buildFailure', err));
+    return this._lifetimeDeferred.promise;
+  }
+
+  quit() {
+    this._lifetimeDeferred.resolve();
+  }
+}
+
+RSVP.EventTarget.mixin(Watcher.prototype);
+
+module.exports = Watcher;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,9 +13,6 @@ module.exports = {
   get getMiddleware() {
     return require('./middleware');
   },
-  get DummyWatcher() {
-    return require('./dummy-watcher');
-  },
   get Watcher() {
     return require('./watcher');
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,9 @@ module.exports = {
   get getMiddleware() {
     return require('./middleware');
   },
+  get DummyWatcher() {
+    return require('./dummy-watcher');
+  },
   get Watcher() {
     return require('./watcher');
   },

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const printSlowNodes = require('broccoli-slow-trees');
+
+module.exports = {
+  onBuildSuccess(builder) {
+    printSlowNodes(builder.outputNodeWrapper);
+    console.log(
+      'Built - ' +
+        Math.round(builder.outputNodeWrapper.buildState.totalTime) +
+        ' ms @ ' +
+        new Date().toString()
+    );
+  },
+
+  onBuildFailure(err) {
+    console.log('Built with error:');
+    console.log(err.message);
+    if (!err.broccoliPayload || !err.broccoliPayload.location.file) {
+      console.log('');
+      console.log(err.stack);
+    }
+    console.log('');
+  },
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -54,12 +54,13 @@ exports.serve = function serve(watcher, host, port, _connect) {
     console.log('');
   });
 
-  server.watcher
+  server.closingPromise = server.watcher
     .start()
     .catch(err => console.log((err && err.stack) || err))
     .finally(() => {
       server.builder.cleanup();
       server.http.close();
+      process.exit(0);
     })
     .catch(err => {
       console.log('Cleanup error:');

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const middleware = require('./middleware');
 const http = require('http');
-const printSlowNodes = require('broccoli-slow-trees');
+
+const messages = require('./messages');
+const middleware = require('./middleware');
 
 exports.serve = function serve(watcher, host, port, _connect) {
   if (watcher.constructor.name !== 'Watcher') throw new Error('Expected Watcher instance');
@@ -13,15 +14,7 @@ exports.serve = function serve(watcher, host, port, _connect) {
   let connect = arguments.length > 3 ? _connect : require('connect');
 
   const server = {
-    onBuildSuccessful() {
-      printSlowNodes(server.builder.outputNodeWrapper);
-      console.log(
-        'Built - ' +
-          Math.round(server.builder.outputNodeWrapper.buildState.totalTime) +
-          ' ms @ ' +
-          new Date().toString()
-      );
-    },
+    onBuildSuccessful: () => messages.onBuildSuccess(watcher.builder),
     cleanupAndExit,
   };
 
@@ -43,16 +36,7 @@ exports.serve = function serve(watcher, host, port, _connect) {
   process.on('SIGTERM', cleanupAndExit);
 
   server.watcher.on('buildSuccess', () => server.onBuildSuccessful());
-
-  server.watcher.on('buildFailure', err => {
-    console.log('Built with error:');
-    console.log(err.message);
-    if (!err.broccoliPayload || !err.broccoliPayload.location.file) {
-      console.log('');
-      console.log(err.stack);
-    }
-    console.log('');
-  });
+  server.watcher.on('buildFailure', messages.onBuildFailure);
 
   server.closingPromise = server.watcher
     .start()

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -7,6 +7,7 @@ const sinon = require('sinon').createSandbox();
 const sinonChai = require('sinon-chai');
 
 const Builder = require('../lib/builder');
+const DummyWatcher = require('../lib/dummy-watcher');
 const broccoli = require('../lib/index');
 const cli = require('../lib/cli');
 const loadBrocfile = require('../lib/load_brocfile');
@@ -239,11 +240,7 @@ describe('cli', function() {
         server
           .expects('serve')
           .once()
-          .withArgs(
-            sinon.match.instanceOf(broccoli.DummyWatcher),
-            sinon.match.string,
-            sinon.match.number
-          );
+          .withArgs(sinon.match.instanceOf(DummyWatcher), sinon.match.string, sinon.match.number);
         cli(['node', 'broccoli', 'serve', '--no-watch']);
         server.verify();
       });

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -26,6 +26,8 @@ describe('cli', function() {
   afterEach(function() {
     sinon.restore();
     process.chdir(oldCwd);
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
   });
 
   describe('build', function() {

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -153,16 +153,6 @@ describe('cli', function() {
       server.verify();
     });
 
-    context('on terminated watcher', function() {
-      it('by SIGTERM exits without error', function() {
-        const returnPromise = cli(['node', 'broccoli', 'serve']);
-        process.kill(process.pid, 'SIGTERM');
-        return returnPromise.then(() => {
-          chai.expect(exitStub).to.be.calledWith(0);
-        });
-      });
-    });
-
     it('converts port to a number and starts the server at given port and host', function() {
       server
         .expects('serve')

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -19,6 +19,9 @@ describe('server', function() {
   });
 
   afterEach(function() {
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+
     let closingPromise = Promise.resolve();
 
     if (server) {

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -64,8 +64,9 @@ describe('server', function() {
         } catch (e) {
           reject(e);
         }
+        watcher.quit();
       };
-    });
+    }).then(() => server.closingPromise);
   });
 
   it('supports being provided a custom connect middleware root', function() {
@@ -94,7 +95,8 @@ describe('server', function() {
         } catch (e) {
           reject(e);
         }
+        watcher.quit();
       };
-    });
+    }).then(() => server.closingPromise);
   });
 });


### PR DESCRIPTION
To be merged after: https://github.com/broccolijs/broccoli/pull/341
Implements another part of: https://github.com/broccolijs/broccoli/issues/331
Closes: https://github.com/broccolijs/broccoli/issues/184

Notable changes:
* build/serve share some console output encapsulated in `lib/messages.js`
* `lib/cli.js` always return the promise to simplify testing (no more `nextTick`)

Questions: 
* listening to OS signals is duplicated in `lib/cli.js` and `lib/server.js` - I think we can remove it from server completely as it should probably be hosting program responsibility (in this case the cli)
* `lib/dummy-watcher.js` is a way to make `lib/server.js` run correctly without code reloading, but the name is not very descriptive and it is not clear if it should be a part of public interface