### PR TITLE
Add Build Cancellation

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -15,6 +15,7 @@ const SourceNodeWrapper = require('./wrappers/source-node');
 const BuilderError = require('./errors/builder');
 const NodeSetupError = require('./errors/node-setup');
 const BuildError = require('./errors/build');
+const CancelationRequest = require('./cancellation-request');
 
 // Clean up left-over temporary directories on uncaught exception.
 tmp.setGracefulCleanup();
@@ -61,6 +62,7 @@ module.exports = class Builder {
     this.checkInputPathsExist();
 
     this.setupTmpDirs();
+    this._cancelationRequest = undefined;
 
     // Now that temporary directories are set up, we need to run the rest of the
     // constructor in a try/catch block to clean them up if necessary.
@@ -81,8 +83,16 @@ module.exports = class Builder {
   // This method will never throw, and it will never be rejected with anything
   // other than a BuildError.
   build() {
+    if (this._cancelationRequest) {
+      return RSVP.Promise.reject(
+        new BuilderError('Cannot start a build if one is already running')
+      );
+    }
+
+    let promise = RSVP.Promise.resolve();
+
     this.buildId++;
-    let promise = RSVP.resolve();
+
     this.nodeWrappers.forEach(nw => {
       // We use `.forEach` instead of `for` to close nested functions over `nw`
 
@@ -93,16 +103,36 @@ module.exports = class Builder {
         // We use a nested .then/.catch so that the .catch can only catch errors
         // from this node, but not from previous nodes.
         return RSVP.resolve()
+          .then(() => this._cancelationRequest.throwIfRequested())
           .then(() => this.trigger('beginNode', nw))
           .then(() => nw.build())
-          .finally(() => this.trigger('endNode', nw))
+          .finally(() => {
+            if (this._cancelationRequest.isCancelled) {
+              return;
+            }
+            this.trigger('endNode', nw);
+          })
+          .then(() => this._cancelationRequest.throwIfRequested())
           .catch(err => {
             throw new BuildError(err, nw);
           });
       });
     });
 
-    return promise;
+    this._cancelationRequest = new CancelationRequest(promise);
+
+    return promise.finally(() => {
+      this._cancelationRequest = null;
+    });
+  }
+
+  cancel() {
+    if (!this._cancelationRequest) {
+      // No current build, so no cancellation
+      return RSVP.Promise.resolve();
+    }
+
+    return this._cancelationRequest.cancel();
   }
 
   // Destructor-like method. Cleanup is synchronous at the moment, but in the

--- a/lib/cancellation-request.js
+++ b/lib/cancellation-request.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const CancelationError = require('./errors/cancelation');
+const BuilderError = require('./errors/builder');
+
+module.exports = class CancelationRequest {
+  constructor(pendingWork) {
+    this._isCancelled = false;
+    this._pendingWork = pendingWork; // all
+  }
+
+  get isCancelled() {
+    return this._isCancelled;
+  }
+
+  throwIfRequested() {
+    if (this._isCancelled) {
+      throw new CancelationError('BUILD CANCELLED');
+    }
+  }
+
+  cancel() {
+    // if we ever expose the cancellation to plugins, we should not expose
+    // cancel(), rather it should be expose similarity to the Promise
+    // executor
+    this._isCancelled = true;
+
+    return this._pendingWork.catch(e => {
+      // a rejection with a cancel cancel promise
+      if (BuilderError.isBuilderError(e)) {
+        return;
+      }
+
+      throw e;
+    });
+  }
+};

--- a/lib/errors/build.js
+++ b/lib/errors/build.js
@@ -44,7 +44,10 @@ module.exports = class BuildError extends BuilderError {
       instantiationStack;
 
     super(message);
+    // consider for x in y
     this.stack = originalError.stack;
+    this.isSilent = originalError.isSilent;
+    this.isCancellation = originalError.isCancellation;
 
     // This error API can change between minor Broccoli version bumps
     this.broccoliPayload = {

--- a/lib/errors/cancelation.js
+++ b/lib/errors/cancelation.js
@@ -1,9 +1,9 @@
 'use strict';
 
 // Base class for builder errors
-module.exports = class BuilderError extends Error {
-  static isBuilderError(error) {
-    return error !== null && typeof error === 'object' && error.isBuilderError;
+module.exports = class Cancellation extends Error {
+  static isCancellation(e) {
+    return typeof e === 'object' && e !== null && e.isCancellation == true;
   }
 
   constructor(a, b, c) {
@@ -16,6 +16,8 @@ module.exports = class BuilderError extends Error {
     temp.name = this.name = this.constructor.name;
     this.stack = temp.stack;
     this.message = temp.message;
-    this.isBuilderError = true;
+
+    this.isCancellation = true;
+    this.isSilent = true;
   }
 };

--- a/test/cancellation-request-test.js
+++ b/test/cancellation-request-test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const chaiAsPromised = require('chai-as-promised');
+const CancelationRequest = require('../lib/cancellation-request');
+const RSVP = require('rsvp');
+const BuilderError = require('../lib/errors/builder');
+
+chai.use(chaiAsPromised);
+
+describe('cancellation-request', function() {
+  it('.isCancelled / .cancel', function() {
+    let request = new CancelationRequest(RSVP.Promise.resolve());
+
+    expect(request.isCancelled).to.eql(false);
+    let wait = request.cancel();
+    expect(request.isCancelled).to.eql(true);
+
+    return wait.then(() => {
+      expect(request.isCancelled).to.eql(true);
+    });
+  });
+
+  it('.throwIfRequested (requested)', function() {
+    let request = new CancelationRequest(RSVP.Promise.resolve());
+
+    request.throwIfRequested();
+
+    return request.cancel().then(() => {
+      expect(() => {
+        request.throwIfRequested();
+      }).to.throw('BUILD CANCELLED');
+
+      expect(() => {
+        request.throwIfRequested();
+      }).to.throw('BUILD CANCELLED');
+    });
+  });
+
+  it('.cancel (with builder rejection)', function() {
+    let request = new CancelationRequest(RSVP.Promise.reject(new BuilderError()));
+
+    return request.cancel();
+  });
+
+  it('.cancel (with non-builder rejection)', function() {
+    let request = new CancelationRequest(RSVP.Promise.reject(new Error('OOPS')));
+
+    return expect(request.cancel()).to.eventually.be.rejectedWith('OOPS');
+  });
+});


### PR DESCRIPTION
### Descrption

For larger builds, it is important that a mid-build `<ctrl-c>` can both gracefully exit, but also exist as fast as possible. In-order to accomplish this, we need to be able to terminate the build after the current step completes.

Also for larger builds, it is important that if a new change event occurs mid-build, that we can pause the build after the current step, and resume it from the beginning (in a safe way). This provides a good user-experience, as 2 changes slower then the throttle threshold but faster then a rebuild will still only produce 1 consistent output. No accidentally mid-build stale outputs.

```
builder.cancel().then(() => /* the build was cancelled */);
```

### TODOS

- [x] a fulfilled `cancel` guarantees to leave the build in a resumable state
- [x]  a rejected `cancel` suggests a unrecoverable build
- [x] `builder.cancel()` will currently wait for the current step to an, before cancelling the build. This is to ensure the build is resumable, and can be lifted in the future with more work.
- [x] a `builder.buid()` is not allowed if the `builder` currently has a pending build or cancellation
- [x] `builder.cancel` is idempotent
- [x] events (‘nodeStart’ ‘nodeEnd’) remain balanced in-light or cancellation
- [x] CancellationErrors are `isSilent` and `isCancellation` to play nicely with consumers like ember-cli

TODO: 

- [ ] mid-build change events should cancel the current build and queue up behind the existing cancel before kicking off another build.
- [x] better error messages
- [ ] wire up signals so the CLI gets cancellation on <ctrl-c> etc.