### PR TITLE
Overwrite output

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,7 @@ const TreeSync = require('tree-sync');
 const childProcess = require('child_process');
 const fs = require('fs');
 const WatchDetector = require('watch-detector');
+const rimraf = require('rimraf');
 
 const broccoli = require('./index');
 const messages = require('./messages');
@@ -27,6 +28,7 @@ module.exports = function broccoliCLI(args) {
     .option('--output-path <path>', 'the path to target output folder')
     .option('--no-watch', 'turn off the watcher')
     .option('--watcher <watcher>', 'select sane watcher mode')
+    .option('--overwrite', 'overwrite the [target/--output-path] directory')
     .action(options => {
       const builder = getBuilder({ brocfilePath: options.brocfilePath });
       const Watcher = getWatcher(options.watch);
@@ -34,7 +36,7 @@ module.exports = function broccoliCLI(args) {
       const watcher = new Watcher(builder, buildWatcherOptions(options));
 
       if (outputDir) {
-        guardOutputDir(outputDir);
+        guardOutputDir(outputDir, options.overwrite);
         const outputTree = new TreeSync(builder.outputPath, outputDir);
 
         watcher.on('buildSuccess', function() {
@@ -54,6 +56,7 @@ module.exports = function broccoliCLI(args) {
     .option('--output-path <path>', 'the path to target output folder')
     .option('--watch', 'turn on the watcher')
     .option('--watcher <watcher>', 'select sane watcher mode')
+    .option('--overwrite', 'overwrite the [target/--output-path] directory')
     .action((outputDir, options) => {
       if (outputDir && options.outputPath) {
         console.error('option --output-path and [target] cannot be passed at same time');
@@ -68,7 +71,7 @@ module.exports = function broccoliCLI(args) {
         outputDir = 'dist';
       }
 
-      guardOutputDir(outputDir);
+      guardOutputDir(outputDir, options.overwrite);
 
       const builder = getBuilder({ brocfilePath: options.brocfilePath });
       const Watcher = getWatcher(options.watch);
@@ -154,9 +157,17 @@ function buildWatcherOptions(options) {
   };
 }
 
-function guardOutputDir(outputDir) {
+function guardOutputDir(outputDir, removeExisting) {
   if (fs.existsSync(outputDir)) {
-    console.error(outputDir + '/ already exists; we cannot build into an existing directory');
+    if (removeExisting) {
+      rimraf.sync(outputDir);
+      return;
+    }
+    console.error(
+      outputDir +
+        '/ already exists; we cannot build into an existing directory, ' +
+        'pass --overwrite to auto-delete the output directory'
+    );
     process.exit(1);
   }
 }

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -202,6 +202,13 @@ describe('cli', function() {
           consoleMock.verify();
         });
       });
+
+      it('accepts --overwrite option', function() {
+        fs.mkdirSync('dist');
+        return cli(['node', 'broccoli', 'build', '--overwrite']).then(() => {
+          chai.expect(fs.existsSync('dist')).to.be.true;
+        });
+      });
     });
   });
 
@@ -407,6 +414,13 @@ describe('cli', function() {
           )
         )
       );
+    });
+
+    it('accepts --overwrite option', function() {
+      fs.mkdirSync('dist');
+      return cli(['node', 'broccoli', 'build', '--overwrite']).then(() => {
+        chai.expect(fs.existsSync('dist')).to.be.true;
+      });
     });
   });
 });

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -329,7 +329,9 @@ describe('cli', function() {
           consoleMock
             .expects('error')
             .once()
-            .withArgs('subdir/ already exists; we cannot build into an existing directory');
+            .withArgs(
+              'subdir/ already exists; we cannot build into an existing directory, pass --overwrite to auto-delete the output directory'
+            );
 
           sinon.stub(broccoli, 'server').value({ serve() {} });
           return cli(['node', 'broccoli', 'serve', '--output-path', 'subdir']).then(() => {


### PR DESCRIPTION
This PR adds an `--overwrite` CLI option to the build command.
It's very frustrating to have to remove the output directory before each build, so this fixes that issue.