### PR TITLE
 Add CliError & returns to exits

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -135,7 +135,7 @@ module.exports = function broccoliCLI(args) {
 
   if (!actionPromise) {
     program.outputHelp();
-    process.exit(1);
+    return process.exit(1);
   }
 
   return actionPromise || RSVP.resolve();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,6 +9,7 @@ const rimraf = require('rimraf');
 
 const broccoli = require('./index');
 const messages = require('./messages');
+const CliError = require('./errors/cli');
 
 module.exports = function broccoliCLI(args) {
   // always require a fresh commander, as it keeps state at module scope
@@ -37,7 +38,17 @@ module.exports = function broccoliCLI(args) {
       const watcher = new Watcher(builder, buildWatcherOptions(options));
 
       if (outputDir) {
-        guardOutputDir(outputDir, options.overwrite);
+        try {
+          guardOutputDir(outputDir, options.overwrite);
+        } catch (e) {
+          if (e instanceof CliError) {
+            console.error(e.message);
+            return process.exit(1);
+          } else {
+            throw e;
+          }
+        }
+
         const outputTree = new TreeSync(builder.outputPath, outputDir);
 
         watcher.on('buildSuccess', function() {
@@ -62,7 +73,7 @@ module.exports = function broccoliCLI(args) {
     .action((outputDir, options) => {
       if (outputDir && options.outputPath) {
         console.error('option --output-path and [target] cannot be passed at same time');
-        process.exit(1);
+        return process.exit(1);
       }
 
       if (options.outputPath) {
@@ -73,7 +84,16 @@ module.exports = function broccoliCLI(args) {
         outputDir = 'dist';
       }
 
-      guardOutputDir(outputDir, options.overwrite);
+      try {
+        guardOutputDir(outputDir, options.overwrite);
+      } catch (e) {
+        if (e instanceof CliError) {
+          console.error(e.message);
+          return process.exit(1);
+        } else {
+          throw e;
+        }
+      }
 
       const builder = getBuilder(options);
       const Watcher = getWatcher(options);
@@ -163,11 +183,10 @@ function guardOutputDir(outputDir, removeExisting) {
       rimraf.sync(outputDir);
       return;
     }
-    console.error(
+    throw new CliError(
       outputDir +
         '/ already exists; we cannot build into an existing directory, ' +
         'pass --overwrite to auto-delete the output directory'
     );
-    process.exit(1);
   }
 }

--- a/lib/errors/cli.js
+++ b/lib/errors/cli.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// Base class for cli errors
+module.exports = class CliError extends Error {};

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -213,9 +213,8 @@ describe('cli', function() {
 
       context('and with [target]', function() {
         it('exits with error', function() {
-          return cli(['node', 'broccoli', 'build', 'dist', '--output-path', 'dist']).then(() => {
-            chai.expect(exitStub).to.be.calledWith(1);
-          });
+          cli(['node', 'broccoli', 'build', 'dist', '--output-path', 'dist']);
+          chai.expect(exitStub).to.be.calledWith(1);
         });
 
         it('outputs error reason to console', function() {
@@ -360,9 +359,8 @@ describe('cli', function() {
       context('and with folder already existing', function() {
         it('exits with error', function() {
           sinon.stub(broccoli, 'server').value({ serve() {} });
-          return cli(['node', 'broccoli', 'serve', '--output-path', 'subdir']).then(() => {
-            chai.expect(exitStub).to.be.calledWith(1);
-          });
+          cli(['node', 'broccoli', 'serve', '--output-path', 'subdir']);
+          chai.expect(exitStub).to.be.calledWith(1);
         });
 
         it('outputs error reason to console', function() {
@@ -375,9 +373,8 @@ describe('cli', function() {
             );
 
           sinon.stub(broccoli, 'server').value({ serve() {} });
-          return cli(['node', 'broccoli', 'serve', '--output-path', 'subdir']).then(() => {
-            consoleMock.verify();
-          });
+          cli(['node', 'broccoli', 'serve', '--output-path', 'subdir']);
+          consoleMock.verify();
         });
       });
     });


### PR DESCRIPTION
Whilst working on https://github.com/broccolijs/broccoli/pull/358 I've discovered that when mocking `process.exit()`, execution continues after the `exit()` which causes weird test behavior, as the process isn't actually exiting.

This PR adds some `return` lines in before each `process.exit()` to ensure that we stop processing.
It also adds a `CliError` class, so the `guardOutputDir()` method can throw an exception that can be caught, and the process.exit can be contained within the main cli program, and thus returned.

As such, a couple of tests needed to be updated as they were using APIs as a result of the execution not actually exiting. They are now synchronous rather than async with a promise.