### PR TITLE
Remove test/.jshintrc and replace with test/.eslintrc.js

### DIFF
--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: "../.eslintrc.js",
+  env: {
+    mocha: true
+  }
+}

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,5 +1,4 @@
 module.exports = {
-  extends: "../.eslintrc.js",
   env: {
     mocha: true
   }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,5 +1,0 @@
-{
-  "extends": "../.jshintrc",
-  "mocha": true,
-  "expr": true
-}


### PR DESCRIPTION
We don't use jshint any more, looks like this was never changed.
Not sure what `expr` is or what the `eslint` equivalent is