### PR TITLE
Add Heimdall support

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const RSVP = require('rsvp');
 const tmp = require('tmp');
+const heimdall = require('heimdalljs');
 const underscoreString = require('underscore.string');
 const WatchedDir = require('broccoli-source').WatchedDir;
 const broccoliNodeInfo = require('broccoli-node-info');
@@ -62,6 +63,7 @@ module.exports = class Builder {
     this.checkInputPathsExist();
 
     this.setupTmpDirs();
+    this.setupHeimdall();
     this._cancelationRequest = undefined;
 
     // Now that temporary directories are set up, we need to run the rest of the
@@ -124,6 +126,10 @@ module.exports = class Builder {
     return promise
       .then(() => {
         return this.outputNodeWrapper;
+      })
+      .then(outputNodeWrapper => {
+        this.buildHeimdallTree(outputNodeWrapper);
+        return outputNodeWrapper;
       })
       .finally(() => {
         this._cancelationRequest = null;
@@ -334,6 +340,91 @@ module.exports = class Builder {
         throw new NodeSetupError(err, nw);
       }
     }
+  }
+
+  setupHeimdall() {
+    this.on('beginNode', node => {
+      let name;
+
+      if (node instanceof SourceNodeWrapper) {
+        name = node.nodeInfo.sourceDirectory;
+      } else {
+        name = node.nodeInfo.annotation || node.nodeInfo.name;
+      }
+
+      node.__heimdall_cookie__ = heimdall.start({
+        name,
+        label: node.label,
+        broccoliNode: true,
+        broccoliId: node.id,
+        broccoliCachedNode: false,
+        broccoliPluginName: node.nodeInfo.name,
+      });
+      node.__heimdall__ = heimdall.current;
+    });
+
+    this.on('endNode', node => {
+      if (node.__heimdall__) {
+        node.__heimdall_cookie__.stop();
+      }
+    });
+  }
+
+  buildHeimdallTree(outputNodeWrapper) {
+    const heimdallRootNode = outputNodeWrapper.__heimdall__;
+    const heimdallByBroccoliId = {};
+
+    if (!heimdallRootNode) {
+      return;
+    }
+
+    heimdallRootNode.parent.forEachChild(child => {
+      if (!child.id.broccoliNode) {
+        return;
+      }
+
+      // Skip the outputNodeWrapper node
+      if (child === heimdallRootNode) {
+        return;
+      }
+
+      heimdallByBroccoliId[child.id.broccoliId] = child;
+    });
+
+    const processed = {};
+
+    // Traverse the node tree from bottom to top, and add each node to its parents children
+    const traverseTree = function traverseTree(nodeWrapper, heimdallNode) {
+      heimdallNode.stats.time.total = heimdallNode.stats.time.self;
+
+      // Iterate each inputNodeWrapper and push this nodes onto its children
+      for (let inputNodeWrapper of nodeWrapper.inputNodeWrappers) {
+        let childHeimdallNode = heimdallByBroccoliId[inputNodeWrapper.id];
+
+        // Heimdall does not allow multiple parents. As such, we must create a new "dummy" node
+        // for any nodes that are re-used (like source nodes).
+        if (processed[inputNodeWrapper.id]) {
+          const cookie = heimdall.start(Object.assign({}, childHeimdallNode.id));
+          childHeimdallNode = heimdall.current;
+          childHeimdallNode.id.broccoliCachedNode = true;
+          cookie.stop();
+          childHeimdallNode.stats.time.self = 0;
+        }
+
+        // Track that this node has been processed so we can duplicate above
+        processed[inputNodeWrapper.id] = true;
+
+        // Remove the node from its existing parent, and add to this node
+        childHeimdallNode.remove();
+        heimdallNode.addChild(childHeimdallNode);
+        heimdallNode.stats.time.total += traverseTree(inputNodeWrapper, childHeimdallNode);
+      }
+
+      return heimdallNode.stats.time.total;
+    };
+
+    const time = traverseTree(outputNodeWrapper, heimdallRootNode);
+    heimdallRootNode.parent.stats.time.total = heimdallRootNode.parent.stats.time.self + time;
   }
 
   get features() {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "connect": "^3.6.5",
     "findup-sync": "^2.0.0",
     "handlebars": "^4.0.11",
+    "heimdalljs": "^0.2.3",
     "heimdalljs-logger": "^0.1.9",
     "mime": "^1.5.0",
     "rimraf": "^2.6.2",

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -84,12 +84,15 @@ module.exports = function(Plugin) {
 
   plugins.Sleeping = class SleepingPlugin extends CountingPlugin {
     constructor(inputNodes, options) {
+      options = options || {};
+      options.sleep = options.sleep || 10;
       super(inputNodes || [], options);
+      this.options = options;
     }
 
     build() {
       super.build();
-      return new RSVP.Promise(resolve => setTimeout(resolve, 10));
+      return new RSVP.Promise(resolve => setTimeout(resolve, this.options.sleep));
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,12 @@ heimdalljs-logger@^0.1.7, heimdalljs-logger@^0.1.9:
     debug "^2.2.0"
     heimdalljs "^0.2.0"
 
+heimdalljs@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.3.tgz#35b82a6a4d73541fc4fb88d2fe2b23608fb4f779"
+  dependencies:
+    rsvp "~3.2.1"
+
 heimdalljs@^0.2.0:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"


### PR DESCRIPTION
This PR adds heimdall stats support to Broccoli master.

This is ported from https://github.com/ember-cli/broccoli-builder
I've tried to setup the test in as close a representation to the original as possible.

What we're doing is registering the `beginNode` and `endNode` events to start/stop the heimdall timer, but these events are no longer "nested" as they are in Broccoli < 1.0. As a result, to get the nested structure that heimdall needs to do flame graphs, etc, we need to reconstruct this graph using the Broccoli node graph.

Additionally, because Broccoli re-uses nodes (for source directories), and heimdall does NOT allow you to have a node with multiple parents, we're simulating a new heimdall node, in the same way as we're doing it in Broccoli < 1.0 https://github.com/ember-cli/broccoli-builder/blob/0-18-x/lib/builder.js#L101-L107 => https://github.com/broccolijs/broccoli/pull/362/files#diff-dde50c51d91de11d407f53423f3baeecR399]]]

Here's a vis output (running BROCCOLI_VIZ=1 ember build) for `broccoli 1.0` and current `master` for 2 builds:

I used https://github.com/ember-cli/broccoli-builder/pull/27 for the `broccoli-builder` branch as this makes the labels more informative and closer to `broccoli` (which I think is good).

`full` - a regular build of ember on a fresh application
`slim` - a simple build (2 nodes and a merge)

[Archive.zip](https://github.com/broccolijs/broccoli/files/2020799/Archive.zip)


These can be uploaded to https://rwjblue.github.io/heimdalljs-visualizer

They produce the following results:

`broccoli-full`:

![image](https://user-images.githubusercontent.com/1246671/40283880-cdf8b5c6-5c53-11e8-99d6-e6093393ef29.png)
![image](https://user-images.githubusercontent.com/1246671/40283882-d5a5c534-5c53-11e8-8e59-f85af698a168.png)


`master-full`:
![image](https://user-images.githubusercontent.com/1246671/40284477-be4c3968-5c5d-11e8-825c-953528bd0b1d.png)

![image](https://user-images.githubusercontent.com/1246671/40284480-c5a75062-5c5d-11e8-9b1a-a4e2fd2bb8cc.png)



`broccoli-slim`:

![image](https://user-images.githubusercontent.com/1246671/40283889-ebe5aac6-5c53-11e8-8862-8847ded013c7.png)

![image](https://user-images.githubusercontent.com/1246671/40283939-9bb3668c-5c54-11e8-9de2-f471031fe265.png)




`master-slim`:

![image](https://user-images.githubusercontent.com/1246671/40283892-f9c36476-5c53-11e8-80c3-07600ecd781e.png)


![image](https://user-images.githubusercontent.com/1246671/40284526-655e900c-5c5e-11e8-981a-5f04ebfd30f5.png)


As you can see, both flame graphs are the same, and `broccoli-1` is slightly faster

# Note
There appears to be a bug in the ordering of the output in the flame graph, looking into it...