### PR TITLE
 Return outputNode from build promise

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -121,9 +121,13 @@ module.exports = class Builder {
 
     this._cancelationRequest = new CancelationRequest(promise);
 
-    return promise.finally(() => {
-      this._cancelationRequest = null;
-    });
+    return promise
+      .then(() => {
+        return this.outputNodeWrapper;
+      })
+      .finally(() => {
+        this._cancelationRequest = null;
+      });
   }
 
   cancel() {

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const RSVP = require('rsvp');
 const tmp = require('tmp');
 const broccoli = require('..');
+const TransformNode = require('../lib/wrappers/transform-node');
 const makePlugins = require('./plugins');
 const Builder = broccoli.Builder;
 const fixturify = require('fixturify');
@@ -83,6 +84,7 @@ describe('Builder', function() {
       let promise = builder.build();
 
       return promise.then(node => {
+        expect(node).to.be.an.instanceOf(TransformNode);
         expect(node.node).to.be.an.instanceOf(plugins.Noop);
       });
     });

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -69,6 +69,25 @@ describe('Builder', function() {
     }
   });
 
+  describe('build result', function() {
+    it('returns a promise', function() {
+      let stepA = new plugins.Noop();
+      let builder = new Builder(stepA);
+      let promise = builder.build();
+      expect(promise).to.be.an.instanceOf(RSVP.Promise);
+    });
+
+    it('promise resolves to a node', function() {
+      let stepA = new plugins.Noop();
+      let builder = new Builder(stepA);
+      let promise = builder.build();
+
+      return promise.then(node => {
+        expect(node.node).to.be.an.instanceOf(plugins.Noop);
+      });
+    });
+  });
+
   describe('broccoli-plugin nodes (nodeType: "transform")', function() {
     multidepRequire.forEachVersion('broccoli-plugin', function(version, Plugin) {
       const plugins = makePlugins(Plugin);


### PR DESCRIPTION
This PR adds 1 feature to enable broccoli master to work in ember-cli (plus a small tweak to re-implement the `summarize` method below):

Make the `build` promise return `outputNode` as the result, this is consistent with `broccoli-builder` and required for `ember-cli` to function correctly. This can be seen here:
https://github.com/ember-cli/broccoli-builder/blob/d3add6436f8e1c29f4532482bf7fda8dc10b0017/lib/builder.js#L52
The above `readAndReturnNodeFor` returns the last node, the `outputNode` in broccoli nomenclature.
This is then passed to `summarize`:
https://github.com/ember-cli/broccoli-builder/blob/d3add6436f8e1c29f4532482bf7fda8dc10b0017/lib/builder.js#L54
which reformats it into an object:
https://github.com/ember-cli/broccoli-builder/blob/d3add6436f8e1c29f4532482bf7fda8dc10b0017/lib/builder.js#L29-L34
This object is then passed from the ember-cli chain of `thens`:
https://github.com/ember-cli/ember-cli/blob/689bdbfee75ef92a33a86466669062bfb7507531/lib/models/builder.js#L156
To `processBuildResult` which uses the `.directory` property:
https://github.com/ember-cli/ember-cli/blob/689bdbfee75ef92a33a86466669062bfb7507531/lib/models/builder.js#L113

Once these are merged, this makes broccoli work in ember-cli https://github.com/ember-cli/ember-cli/pull/7798