### PR TITLE
Up node support to node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
-  - "stable"
+  - "9"
+  - "10"
 sudo: false
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,10 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "9"
+    - nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
Well, 4 is no longer supported, 10 is the new shiny.
Added version 9 test support too.