### PR TITLE
Implement cleanup promise

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -71,7 +71,7 @@ module.exports = class Builder {
       this.outputPath = this.outputNodeWrapper.outputPath;
       this.buildId = 0;
     } catch (e) {
-      this.cleanup();
+      this.cleanupSync();
       throw e;
     }
   }
@@ -135,10 +135,24 @@ module.exports = class Builder {
     return this._cancelationRequest.cancel();
   }
 
-  // Destructor-like method. Cleanup is synchronous at the moment, but in the
-  // future we might change it to return a promise.
+  /**
+   * Cleanup removes the temporary directory. This is wrapped in a promise to make it non-blocking.
+   * @method cleanup
+   * @return {Promise}
+   */
   cleanup() {
-    this.builderTmpDirCleanup();
+    return RSVP.Promise.resolve().then(() => {
+      return this.cleanupSync();
+    });
+  }
+
+  /**
+   * Cleanup removes the temporary directory.
+   * @method cleanup
+   * @return {function}
+   */
+  cleanupSync() {
+    return this.builderTmpDirCleanup();
   }
 
   // This method recursively traverses the node graph and returns a nodeWrapper.

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -424,9 +424,10 @@ describe('Builder', function() {
     it('removes temporary directory when .cleanup() is called', function() {
       builder = new Builder(new plugins.Veggies(), { tmpdir });
       expect(hasBroccoliTmpDir(tmpdir)).to.be.true;
-      builder.cleanup();
-      builder = null;
-      expect(hasBroccoliTmpDir(tmpdir)).to.be.false;
+      return builder.cleanup().then(() => {
+        builder = null;
+        expect(hasBroccoliTmpDir(tmpdir)).to.be.false;
+      });
     });
 
     describe('failing node setup', function() {


### PR DESCRIPTION
This PR makes `cleanup()` return a promise, as is consistent with the `broccoli-builder` api https://github.com/ember-cli/broccoli-builder/blob/d3add6436f8e1c29f4532482bf7fda8dc10b0017/lib/builder.js#L210-L219
and is used in `ember-cli` here:
https://github.com/ember-cli/ember-cli/blob/689bdbfee75ef92a33a86466669062bfb7507531/lib/models/builder.js#L193

This, along with https://github.com/broccolijs/broccoli/pull/363 should allow us to start iterating on `broccoli` master, within `ember-cli`  https://github.com/ember-cli/ember-cli/pull/7798