### PR TITLE
Build promises should not return outputNodeWrapper

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -132,7 +132,6 @@ module.exports = class Builder extends EventEmitter {
         })
         .then(outputNodeWrapper => {
           this.buildHeimdallTree(outputNodeWrapper);
-          return outputNodeWrapper;
         }),
       () => {
         this._cancelationRequest = null;

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -6,7 +6,6 @@ const path = require('path');
 const tmp = require('tmp');
 const promiseFinally = require('promise.prototype.finally');
 const broccoli = require('..');
-const TransformNode = require('../lib/wrappers/transform-node');
 const makePlugins = require('./plugins');
 const Builder = broccoli.Builder;
 const fixturify = require('fixturify');
@@ -84,10 +83,7 @@ describe('Builder', function() {
       let builder = new Builder(stepA);
       let promise = builder.build();
 
-      return promise.then(node => {
-        expect(node).to.be.an.instanceOf(TransformNode);
-        expect(node.node).to.be.an.instanceOf(plugins.Noop);
-      });
+      return promise;
     });
   });
 


### PR DESCRIPTION
The outputNodeWrapper is internal. Also, it is at `builder.outputNodeWrapper`, along with outputPath, and both do not change per build.

Originally this got changed as it was thought to be needed for ember-cli broccoli 2 support.

If we expose any node, I think it should be the heimdall node.