### PR TITLE
Heimdall fix recursive calls

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -375,26 +375,11 @@ module.exports = class Builder extends EventEmitter {
 
   buildHeimdallTree(outputNodeWrapper) {
     const heimdallRootNode = outputNodeWrapper.__heimdall__;
-    const heimdallByBroccoliId = {};
-
     if (!heimdallRootNode) {
       return;
     }
 
-    heimdallRootNode.parent.forEachChild(child => {
-      if (!child.id.broccoliNode) {
-        return;
-      }
-
-      // Skip the outputNodeWrapper node
-      if (child === heimdallRootNode) {
-        return;
-      }
-
-      heimdallByBroccoliId[child.id.broccoliId] = child;
-    });
-
-    const processed = {};
+    const seen = new Set();
 
     // Traverse the node tree from bottom to top, and add each node to its parents children
     const traverseTree = function traverseTree(nodeWrapper, heimdallNode) {
@@ -402,11 +387,11 @@ module.exports = class Builder extends EventEmitter {
 
       // Iterate each inputNodeWrapper and push this nodes onto its children
       for (let inputNodeWrapper of nodeWrapper.inputNodeWrappers) {
-        let childHeimdallNode = heimdallByBroccoliId[inputNodeWrapper.id];
+        let childHeimdallNode = inputNodeWrapper.__heimdall__;
 
         // Heimdall does not allow multiple parents. As such, we must create a new "dummy" node
         // for any nodes that are re-used (like source nodes).
-        if (processed[inputNodeWrapper.id]) {
+        if (seen.has(inputNodeWrapper)) {
           const cookie = heimdall.start(Object.assign({}, childHeimdallNode.id));
           childHeimdallNode = heimdall.current;
           childHeimdallNode.id.broccoliCachedNode = true;
@@ -420,8 +405,8 @@ module.exports = class Builder extends EventEmitter {
         heimdallNode.addChild(childHeimdallNode);
 
         // Track that this node has been processed so we can duplicate above
-        if (!processed[inputNodeWrapper.id]) {
-          processed[inputNodeWrapper.id] = true;
+        if (!seen.has(inputNodeWrapper)) {
+          seen.add(inputNodeWrapper);
           heimdallNode.stats.time.total += traverseTree(inputNodeWrapper, childHeimdallNode);
         }
       }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -410,17 +410,20 @@ module.exports = class Builder extends EventEmitter {
           const cookie = heimdall.start(Object.assign({}, childHeimdallNode.id));
           childHeimdallNode = heimdall.current;
           childHeimdallNode.id.broccoliCachedNode = true;
-          cookie.stop();
           childHeimdallNode.stats.time.self = 0;
+          childHeimdallNode.stats.time.total = 0;
+          cookie.stop();
         }
-
-        // Track that this node has been processed so we can duplicate above
-        processed[inputNodeWrapper.id] = true;
 
         // Remove the node from its existing parent, and add to this node
         childHeimdallNode.remove();
         heimdallNode.addChild(childHeimdallNode);
-        heimdallNode.stats.time.total += traverseTree(inputNodeWrapper, childHeimdallNode);
+
+        // Track that this node has been processed so we can duplicate above
+        if (!processed[inputNodeWrapper.id]) {
+          processed[inputNodeWrapper.id] = true;
+          heimdallNode.stats.time.total += traverseTree(inputNodeWrapper, childHeimdallNode);
+        }
       }
 
       return heimdallNode.stats.time.total;


### PR DESCRIPTION
This PR branches off the work @krisselden did to change from recursive to a stack https://github.com/broccolijs/broccoli/pull/379

I concluded the main difference was *not* recursing for nodes already processed, the fix for that can be seen here https://github.com/broccolijs/broccoli/commit/3fb21cad1d228081892ba99c826285eb8ad49c30

I also cleaned up some unnecessary work of indexing heimdall nodes by broccoli ID as each ndoeWrapper has a __heimdall__ property with the heimdall node anyway. Also used a set for nodes that have been seen already.