### PR TITLE
Have Brocfile.js export a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install --global broccoli-cli
 ## Brocfile.js
 
 A `Brocfile.js` file in the project root contains the build specification. It
-should export a tree.
+should export a function that returns a tree.
 
 A tree can be any string representing a directory path, like `'app'` or
 `'src'`. Or a tree can be an object conforming to the [Plugin API
@@ -35,7 +35,7 @@ The following simple `Brocfile.js` would export the `app/` subdirectory as a
 tree:
 
 ```js
-module.exports = 'app'
+module.exports = () => 'app';
 ```
 
 With that Brocfile, the build result would equal the contents of the `app`
@@ -62,11 +62,13 @@ the following folder within your project folder:
 The following `Brocfile.js` exports the `app/` subdirectory as `appkit/`:
 
 ```js
-var Funnel = require('broccoli-funnel')
+const Funnel = require('broccoli-funnel')
 
-module.exports = new Funnel('app', {
+module.exports = () => {
+ return new Funnel('app', {
   destDir: 'appkit'
-})
+ })
+}
 ```
 
 That example uses the plugin

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -142,7 +142,7 @@ module.exports = function broccoliCLI(args) {
 
 function getBuilder(options) {
   const brocfile = broccoli.loadBrocfile(options);
-  return new broccoli.Builder(brocfile);
+  return new broccoli.Builder(brocfile());
 }
 
 function getWatcher(options) {

--- a/lib/load_brocfile.js
+++ b/lib/load_brocfile.js
@@ -8,25 +8,33 @@ module.exports = function loadBrocfile(options) {
     options = {};
   }
 
-  let brocfile;
+  let brocfilePath;
 
   if (options.brocfilePath) {
-    brocfile = path.resolve(options.brocfilePath);
+    brocfilePath = path.resolve(options.brocfilePath);
   } else {
-    brocfile = findup('Brocfile.js', {
+    brocfilePath = findup('Brocfile.js', {
       nocase: true,
     });
   }
 
-  if (!brocfile) {
+  if (!brocfilePath) {
     throw new Error('Brocfile.js not found');
   }
 
-  const baseDir = options.cwd || path.dirname(brocfile);
+  const baseDir = options.cwd || path.dirname(brocfilePath);
 
   // The chdir should perhaps live somewhere else and not be a side effect of
   // this function, or go away entirely
   process.chdir(baseDir);
 
-  return require(brocfile);
+  // Load brocfile
+  const brocfile = require(brocfilePath);
+
+  if (typeof brocfile === 'function') {
+    return brocfile;
+  }
+
+  // Wrap brocfile result in a function for backwards compatibility
+  return () => brocfile;
 };

--- a/test/fixtures/project/Brocfile-Function.js
+++ b/test/fixtures/project/Brocfile-Function.js
@@ -1,0 +1,1 @@
+module.exports = () => 'subdir';

--- a/test/load_brocfile_test.js
+++ b/test/load_brocfile_test.js
@@ -35,8 +35,8 @@ describe('loadBrocfile', function() {
 
     it('return tree definition', function() {
       const brocfile = loadBrocfile();
-      chai.expect(brocfile).to.be.a('function')
-      chai.expect(brocfile()).to.equal(brocfileFixture)
+      chai.expect(brocfile).to.be.a('function');
+      chai.expect(brocfile()).to.equal(brocfileFixture);
     });
   });
 

--- a/test/load_brocfile_test.js
+++ b/test/load_brocfile_test.js
@@ -5,6 +5,7 @@ const chai = require('chai');
 
 const projectPath = 'test/fixtures/project';
 const brocfileFixture = require('../' + projectPath + '/Brocfile.js');
+const brocfileFunctionFixture = require('../' + projectPath + '/Brocfile-Function.js');
 
 describe('loadBrocfile', function() {
   let oldCwd = null;
@@ -33,7 +34,9 @@ describe('loadBrocfile', function() {
     });
 
     it('return tree definition', function() {
-      chai.expect(loadBrocfile()).to.equal(brocfileFixture);
+      const brocfile = loadBrocfile();
+      chai.expect(brocfile).to.be.a('function')
+      chai.expect(brocfile()).to.equal(brocfileFixture)
     });
   });
 
@@ -43,20 +46,28 @@ describe('loadBrocfile', function() {
     });
 
     it('return tree definition', function() {
-      chai.expect(loadBrocfile()).to.equal(brocfileFixture);
+      chai.expect(loadBrocfile()()).to.equal(brocfileFixture);
     });
   });
 
   context('with path', function() {
     it('return tree definition', function() {
       chai
-        .expect(loadBrocfile({ brocfilePath: projectPath + '/Brocfile.js' }))
+        .expect(loadBrocfile({ brocfilePath: projectPath + '/Brocfile.js' })())
         .to.equal(brocfileFixture);
     });
 
     it('throws error on invalid path', function() {
       const brocfilePath = projectPath + '/missing-brocfile.js';
       chai.expect(() => loadBrocfile({ brocfilePath })).to.throw(Error, /missing-brocfile.js/);
+    });
+  });
+
+  context('with Brocfile that returns a function', function() {
+    it('does not wrap the function', function() {
+      const brocfile = loadBrocfile({ brocfilePath: projectPath + '/Brocfile-Function.js' });
+      chai.expect(brocfile).to.equal(brocfileFunctionFixture);
+      chai.expect(brocfile()).to.equal(brocfileFixture);
     });
   });
 });


### PR DESCRIPTION
This PR implements the basics needed for Brocfile to return a function by default, and wrap existing brocfile exports in a function for backwards compatibility.
The intention for this is to make Broccoli work the same as Ember-CLI (to avoid confusion), and it also paves the way for us to pass in a configuration object containing things like `environment` and other build-time useful info (as Ember-CLI does).

One thing to note, is https://github.com/broccolijs/broccoli/blob/b5e4c8b7bbd378ee02d40779d483fed65439918b/lib/index.js#L7-L9 would now return a function rather than a node. This obviously changes the API, but I don't know if that's an issue or not given there was no test for this else it would have failed.