### PR TITLE
Add BROCCOLI_ENV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ module.exports = (options) => {
 Note: Additionally, `process.env.BROCCOLI_ENV` is supported and contains the same value as `options.env`.
 This allows https://www.npmjs.com/package/broccoli-env and https://github.com/stefanpenner/broccoli-stew
 to function without requiring the additional environment variable being defined at CLI level. Note that
-using `BROCCOLI_ENV` is deprecated and setting environment variable will *NOT* set the `--environment` flag.
+using `BROCCOLI_ENV` is deprecated and setting environment variable will *NOT* set `options.env`.
 
 ### Using plugins in a `Brocfile.js`
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ module.exports = (options) => {
 }
 ```
 
+Note: Additionally, `process.env.BROCCOLI_ENV` is supported and contains the same value as `options.env`.
+
 ### Using plugins in a `Brocfile.js`
 
 The following `Brocfile.js` exports the `app/` subdirectory as `appkit/`:

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ module.exports = (options) => {
 
 Note: Additionally, `process.env.BROCCOLI_ENV` is supported and contains the same value as `options.env`.
 This allows https://www.npmjs.com/package/broccoli-env and https://github.com/stefanpenner/broccoli-stew
-to function without requiring the additional environment variable being defined at CLI level. Note that
-using `BROCCOLI_ENV` is deprecated and setting environment variable will *NOT* set `options.env`.
+to function without requiring the additional environment variable `BROCCOLI_ENV=x` being defined at CLI 
+level. Note that using `BROCCOLI_ENV` environment variable is deprecated and will *NOT* set the value of
+`options.env`.
 
 ### Using plugins in a `Brocfile.js`
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ module.exports = (options) => {
 
 Note: Additionally, `process.env.BROCCOLI_ENV` is supported and contains the same value as `options.env`.
 This allows https://www.npmjs.com/package/broccoli-env and https://github.com/stefanpenner/broccoli-stew
-to function without requiring the additional environment variable being defined at CLI level.
+to function without requiring the additional environment variable being defined at CLI level. Note that
+using `BROCCOLI_ENV` is deprecated and setting environment variable will *NOT* set the `--environment` flag.
 
 ### Using plugins in a `Brocfile.js`
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ module.exports = (options) => {
 ```
 
 Note: Additionally, `process.env.BROCCOLI_ENV` is supported and contains the same value as `options.env`.
+This allows https://www.npmjs.com/package/broccoli-env and https://github.com/stefanpenner/broccoli-stew
+to function without requiring the additional environment variable being defined at CLI level.
 
 ### Using plugins in a `Brocfile.js`
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ module.exports = (options) => {
 }
 ```
 
-Note: Additionally, `process.env.BROCCOLI_ENV` is supported and contains the same value as `options.env`.
-This allows https://www.npmjs.com/package/broccoli-env and https://github.com/stefanpenner/broccoli-stew
-to function without requiring the additional environment variable `BROCCOLI_ENV=x` being defined at CLI 
-level. Note that using `BROCCOLI_ENV` environment variable is deprecated and will *NOT* set the value of
-`options.env`.
+Note: Additionally, the packages [broccoli-env](https://www.npmjs.com/package/broccoli-env) and 
+[broccoli-stew](https://github.com/stefanpenner/broccoli-stew) that use the `BROCCOLI_ENV` environment variable
+will continue to work with the `--environment` option, and the `process.env.BROCCOLI_ENV` environment variable
+will be set to its value. If `--environment` is not set, `BROCCOLI_ENV` will not be overwritten.
+It is not intended that `BROCCOLI_ENV` and `--environment` should be used together.
+Using the `BROCCOLI_ENV` environment variable is deprecated and will be dropped in the future.
 
 ### Using plugins in a `Brocfile.js`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -41,8 +41,15 @@ module.exports = function broccoliCLI(args) {
         options.environment = 'development';
       }
 
-      if (process.env.BROCCOLI_ENV && options.environment) {
-        throw new CliError('You can not use BROCCOLI_ENV and --environment/--prod/--dev together');
+      // Proxy BROCCOLI_ENV to environment
+      if (process.env.BROCCOLI_ENV) {
+        if (options.environment) {
+          throw new CliError(
+            'You can not use BROCCOLI_ENV and --environment/--prod/--dev together'
+          );
+        }
+
+        options.environment = process.env.BROCCOLI_ENV;
       }
 
       // Default environment to development
@@ -112,8 +119,15 @@ module.exports = function broccoliCLI(args) {
         options.environment = 'development';
       }
 
-      if (process.env.BROCCOLI_ENV && options.environment) {
-        throw new CliError('You can not use BROCCOLI_ENV and --environment/--prod/--dev together');
+      // Proxy BROCCOLI_ENV to environment
+      if (process.env.BROCCOLI_ENV) {
+        if (options.environment) {
+          throw new CliError(
+            'You can not use BROCCOLI_ENV and --environment/--prod/--dev together'
+          );
+        }
+
+        options.environment = process.env.BROCCOLI_ENV;
       }
 
       // Default environment to development

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -41,15 +41,8 @@ module.exports = function broccoliCLI(args) {
         options.environment = 'development';
       }
 
-      // Proxy BROCCOLI_ENV to environment
-      if (process.env.BROCCOLI_ENV) {
-        if (options.environment) {
-          throw new CliError(
-            'You can not use BROCCOLI_ENV and --environment/--prod/--dev together'
-          );
-        }
-
-        options.environment = process.env.BROCCOLI_ENV;
+      if (process.env.BROCCOLI_ENV && options.environment) {
+        throw new CliError('You can not use BROCCOLI_ENV and --environment/--prod/--dev together');
       }
 
       // Default environment to development
@@ -119,15 +112,8 @@ module.exports = function broccoliCLI(args) {
         options.environment = 'development';
       }
 
-      // Proxy BROCCOLI_ENV to environment
-      if (process.env.BROCCOLI_ENV) {
-        if (options.environment) {
-          throw new CliError(
-            'You can not use BROCCOLI_ENV and --environment/--prod/--dev together'
-          );
-        }
-
-        options.environment = process.env.BROCCOLI_ENV;
+      if (process.env.BROCCOLI_ENV && options.environment) {
+        throw new CliError('You can not use BROCCOLI_ENV and --environment/--prod/--dev together');
       }
 
       // Default environment to development

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,17 +35,7 @@ module.exports = function broccoliCLI(args) {
     .option('--prod', 'alias for --environment=production')
     .option('--dev', 'alias for --environment=development')
     .action(options => {
-      if (options.prod) {
-        options.environment = 'production';
-      } else if (options.dev) {
-        options.environment = 'development';
-      }
-
-      // Default environment to development
-      options.environment = options.environment || 'development';
-
-      // Set the BROCCOLI_ENV environment variable for broccoli-stew and broccoli-env compat
-      process.env.BROCCOLI_ENV = options.environment;
+      setEnvironment(options);
 
       const builder = getBuilder(options);
       const Watcher = getWatcher(options);
@@ -102,17 +92,7 @@ module.exports = function broccoliCLI(args) {
         outputDir = 'dist';
       }
 
-      if (options.prod) {
-        options.environment = 'production';
-      } else if (options.dev) {
-        options.environment = 'development';
-      }
-
-      // Default environment to development
-      options.environment = options.environment || 'development';
-
-      // Set the BROCCOLI_ENV environment variable for broccoli-stew and broccoli-env compat
-      process.env.BROCCOLI_ENV = options.environment;
+      setEnvironment(options);
 
       try {
         guardOutputDir(outputDir, options.overwrite);
@@ -169,6 +149,29 @@ module.exports = function broccoliCLI(args) {
 
   return actionPromise || Promise.resolve();
 };
+
+function setEnvironment(options) {
+  // Proxy aliases
+  if (options.prod) {
+    options.environment = 'production';
+  } else if (options.dev) {
+    options.environment = 'development';
+  }
+
+  let hasEnv = true;
+
+  // If environment is not defined, default to development
+  if (!options.environment) {
+    options.environment = 'development';
+    hasEnv = false;
+  }
+
+  // If BROCCOLI_ENV environment variable is not set, or environment manually supplied via CLI (overwrite)
+  // Set environment variable for broccoli-stew and broccoli-env compat
+  if (!process.env.BROCCOLI_ENV || hasEnv) {
+    process.env.BROCCOLI_ENV = options.environment;
+  }
+}
 
 function getBuilder(options) {
   const brocfile = broccoli.loadBrocfile(options);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -158,18 +158,11 @@ function setEnvironment(options) {
     options.environment = 'development';
   }
 
-  let hasEnv = true;
-
-  // If environment is not defined, default to development
-  if (!options.environment) {
-    options.environment = 'development';
-    hasEnv = false;
-  }
-
-  // If BROCCOLI_ENV environment variable is not set, or environment manually supplied via CLI (overwrite)
-  // Set environment variable for broccoli-stew and broccoli-env compat
-  if (!process.env.BROCCOLI_ENV || hasEnv) {
+  // If environment manually supplied via CLI (overwrite) set BROCCOLI_ENV for broccoli-stew and broccoli-env compat
+  if (options.environment) {
     process.env.BROCCOLI_ENV = options.environment;
+  } else {
+    options.environment = 'development';
   }
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -31,7 +31,7 @@ module.exports = function broccoliCLI(args) {
     .option('--no-watch', 'turn off the watcher')
     .option('--watcher <watcher>', 'select sane watcher mode')
     .option('--overwrite', 'overwrite the [target/--output-path] directory')
-    .option('-e, --environment <environment>', 'build environment [development]', 'development')
+    .option('-e, --environment <environment>', 'build environment [development]')
     .option('--prod', 'alias for --environment=production')
     .option('--dev', 'alias for --environment=development')
     .action(options => {
@@ -40,6 +40,16 @@ module.exports = function broccoliCLI(args) {
       } else if (options.dev) {
         options.environment = 'development';
       }
+
+      if (process.env.BROCCOLI_ENV && options.environment) {
+        throw new CliError('You can not use BROCCOLI_ENV and --environment/--prod/--dev together');
+      }
+
+      // Default environment to development
+      options.environment = options.environment || 'development';
+
+      // Set the BROCCOLI_ENV environment variable for broccoli-stew and broccoli-env compat
+      process.env.BROCCOLI_ENV = options.environment;
 
       const builder = getBuilder(options);
       const Watcher = getWatcher(options);
@@ -79,7 +89,7 @@ module.exports = function broccoliCLI(args) {
     .option('--watch', 'turn on the watcher')
     .option('--watcher <watcher>', 'select sane watcher mode')
     .option('--overwrite', 'overwrite the [target/--output-path] directory')
-    .option('-e, --environment <environment>', 'build environment [development]', 'development')
+    .option('-e, --environment <environment>', 'build environment [development]')
     .option('--prod', 'alias for --environment=production')
     .option('--dev', 'alias for --environment=development')
     .action((outputDir, options) => {
@@ -101,6 +111,16 @@ module.exports = function broccoliCLI(args) {
       } else if (options.dev) {
         options.environment = 'development';
       }
+
+      if (process.env.BROCCOLI_ENV && options.environment) {
+        throw new CliError('You can not use BROCCOLI_ENV and --environment/--prod/--dev together');
+      }
+
+      // Default environment to development
+      options.environment = options.environment || 'development';
+
+      // Set the BROCCOLI_ENV environment variable for broccoli-stew and broccoli-env compat
+      process.env.BROCCOLI_ENV = options.environment;
 
       try {
         guardOutputDir(outputDir, options.overwrite);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -158,7 +158,7 @@ function setEnvironment(options) {
     options.environment = 'development';
   }
 
-  // If environment manually supplied via CLI (overwrite) set BROCCOLI_ENV for broccoli-stew and broccoli-env compat
+  // If environment manually supplied via CLI set BROCCOLI_ENV for broccoli-stew and broccoli-env compat
   if (options.environment) {
     process.env.BROCCOLI_ENV = options.environment;
   } else {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -41,10 +41,6 @@ module.exports = function broccoliCLI(args) {
         options.environment = 'development';
       }
 
-      if (process.env.BROCCOLI_ENV && options.environment) {
-        throw new CliError('You can not use BROCCOLI_ENV and --environment/--prod/--dev together');
-      }
-
       // Default environment to development
       options.environment = options.environment || 'development';
 
@@ -110,10 +106,6 @@ module.exports = function broccoliCLI(args) {
         options.environment = 'production';
       } else if (options.dev) {
         options.environment = 'development';
-      }
-
-      if (process.env.BROCCOLI_ENV && options.environment) {
-        throw new CliError('You can not use BROCCOLI_ENV and --environment/--prod/--dev together');
       }
 
       // Default environment to development

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -241,17 +241,15 @@ describe('cli', function() {
         );
       });
 
-      it('throws exception if BROCCOLI_ENV and --environment used together', function() {
+      it('overwrites BROCCOLI_ENV with --environment', function() {
         const spy = sinon.spy(loadBrocfile());
         sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
-        process.env.BROCCOLI_ENV = 'production';
+        process.env.BROCCOLI_ENV = 'development';
 
-        chai
-          .expect(() => cli(['node', 'broccoli', 'build', 'dist', '--environment=production']))
-          .to.throw(
-            CliError,
-            'You can not use BROCCOLI_ENV and --environment/--prod/--dev together'
-          );
+        return cli(['node', 'broccoli', 'build', 'dist', '--environment=production']).then(() => {
+          chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
+          chai.expect(process.env.BROCCOLI_ENV).to.equal('production');
+        });
       });
     });
 
@@ -558,17 +556,15 @@ describe('cli', function() {
         chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
       });
 
-      it('throws exception if BROCCOLI_ENV and --environment used together', function() {
+      it('overwrites BROCCOLI_ENV with --environment', function() {
         const spy = sinon.spy(loadBrocfile());
+        sinon.stub(broccoli, 'server').value({ serve() {} });
         sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
-        process.env.BROCCOLI_ENV = 'production';
+        process.env.BROCCOLI_ENV = 'development';
 
-        chai
-          .expect(() => cli(['node', 'broccoli', 'serve', '--environment=production']))
-          .to.throw(
-            CliError,
-            'You can not use BROCCOLI_ENV and --environment/--prod/--dev together'
-          );
+        cli(['node', 'broccoli', 'serve', '--environment=production']);
+        chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
+        chai.expect(process.env.BROCCOLI_ENV).to.equal('production');
       });
     });
   });

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -241,6 +241,16 @@ describe('cli', function() {
         );
       });
 
+      it('proxies process.env.BROCCOLI_ENV to --environment', function() {
+        const spy = sinon.spy(loadBrocfile());
+        sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
+        process.env.BROCCOLI_ENV = 'production';
+
+        return cli(['node', 'broccoli', 'build', 'dist']).then(() => {
+          chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
+        });
+      });
+
       it('throws exception if BROCCOLI_ENV and --environment used together', function() {
         const spy = sinon.spy(loadBrocfile());
         sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
@@ -555,6 +565,16 @@ describe('cli', function() {
         sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
 
         cli(['node', 'broccoli', 'serve', '--prod']);
+        chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
+      });
+
+      it('proxies process.env.BROCCOLI_ENV to --environment', function() {
+        const spy = sinon.spy(loadBrocfile());
+        sinon.stub(broccoli, 'server').value({ serve() {} });
+        sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
+        process.env.BROCCOLI_ENV = 'production';
+
+        cli(['node', 'broccoli', 'serve']);
         chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
       });
 

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -261,17 +261,6 @@ describe('cli', function() {
           chai.expect(process.env.BROCCOLI_ENV).to.equal('production');
         });
       });
-
-      it('overwrites BROCCOLI_ENV if --environment is set', function() {
-        const spy = sinon.spy(loadBrocfile());
-        sinon.stub(broccoli, 'server').value({ serve() {} });
-        sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
-        process.env.BROCCOLI_ENV = 'development';
-
-        cli(['node', 'broccoli', 'serve', '--environment=production']);
-        chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
-        chai.expect(process.env.BROCCOLI_ENV).to.equal('production');
-      });
     });
 
     it('supports `b` alias', function() {

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -240,7 +240,18 @@ describe('cli', function() {
         );
       });
 
-      it('overwrites BROCCOLI_ENV with --environment', function() {
+      it('leaves BROCCOLI_ENV unaltered if --environment is not set', function() {
+        const spy = sinon.spy(loadBrocfile());
+        sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
+        process.env.BROCCOLI_ENV = 'production';
+
+        return cli(['node', 'broccoli', 'build', 'dist']).then(() => {
+          chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'development'));
+          chai.expect(process.env.BROCCOLI_ENV).to.equal('production');
+        });
+      });
+
+      it('overwrites BROCCOLI_ENV if --environment is set', function() {
         const spy = sinon.spy(loadBrocfile());
         sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
         process.env.BROCCOLI_ENV = 'development';
@@ -249,6 +260,17 @@ describe('cli', function() {
           chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
           chai.expect(process.env.BROCCOLI_ENV).to.equal('production');
         });
+      });
+
+      it('overwrites BROCCOLI_ENV if --environment is set', function() {
+        const spy = sinon.spy(loadBrocfile());
+        sinon.stub(broccoli, 'server').value({ serve() {} });
+        sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
+        process.env.BROCCOLI_ENV = 'development';
+
+        cli(['node', 'broccoli', 'serve', '--environment=production']);
+        chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
+        chai.expect(process.env.BROCCOLI_ENV).to.equal('production');
       });
     });
 
@@ -555,7 +577,18 @@ describe('cli', function() {
         chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
       });
 
-      it('overwrites BROCCOLI_ENV with --environment', function() {
+      it('leaves BROCCOLI_ENV unaltered if --environment is not set', function() {
+        const spy = sinon.spy(loadBrocfile());
+        sinon.stub(broccoli, 'server').value({ serve() {} });
+        sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
+        process.env.BROCCOLI_ENV = 'production';
+
+        cli(['node', 'broccoli', 'serve']);
+        chai.expect(process.env.BROCCOLI_ENV).to.equal('production');
+        chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'development'));
+      });
+
+      it('overwrites BROCCOLI_ENV if --environment is set', function() {
         const spy = sinon.spy(loadBrocfile());
         sinon.stub(broccoli, 'server').value({ serve() {} });
         sinon.stub(broccoli, 'loadBrocfile').value(() => spy);

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -241,16 +241,6 @@ describe('cli', function() {
         );
       });
 
-      it('proxies process.env.BROCCOLI_ENV to --environment', function() {
-        const spy = sinon.spy(loadBrocfile());
-        sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
-        process.env.BROCCOLI_ENV = 'production';
-
-        return cli(['node', 'broccoli', 'build', 'dist']).then(() => {
-          chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
-        });
-      });
-
       it('throws exception if BROCCOLI_ENV and --environment used together', function() {
         const spy = sinon.spy(loadBrocfile());
         sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
@@ -565,16 +555,6 @@ describe('cli', function() {
         sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
 
         cli(['node', 'broccoli', 'serve', '--prod']);
-        chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
-      });
-
-      it('proxies process.env.BROCCOLI_ENV to --environment', function() {
-        const spy = sinon.spy(loadBrocfile());
-        sinon.stub(broccoli, 'server').value({ serve() {} });
-        sinon.stub(broccoli, 'loadBrocfile').value(() => spy);
-        process.env.BROCCOLI_ENV = 'production';
-
-        cli(['node', 'broccoli', 'serve']);
         chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'production'));
       });
 

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -10,7 +10,6 @@ const sinonChai = require('sinon-chai');
 
 const Builder = require('../lib/builder');
 const BuilderError = require('../lib/errors/builder');
-const CliError = require('../lib/errors/cli');
 const DummyWatcher = require('../lib/dummy-watcher');
 const broccoli = require('../lib/index');
 const cli = require('../lib/cli');

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -199,7 +199,7 @@ describe('cli', function() {
 
         return cli(['node', 'broccoli', 'build', 'dist']).then(() => {
           chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'development'));
-          chai.expect(process.env.BROCCOLI_ENV).to.equal('development');
+          chai.expect(process.env.BROCCOLI_ENV).to.be.undefined;
         });
       });
 
@@ -526,7 +526,7 @@ describe('cli', function() {
 
         cli(['node', 'broccoli', 'serve']);
         chai.expect(spy).to.be.calledWith(sinon.match.has('env', 'development'));
-        chai.expect(process.env.BROCCOLI_ENV).to.equal('development');
+        chai.expect(process.env.BROCCOLI_ENV).to.be.undefined;
       });
 
       it('with --environment=production passes { env: "production" } and sets process.env.BROCCOLI_ENV', function() {


### PR DESCRIPTION
Given that https://www.npmjs.com/package/broccoli-env and https://github.com/stefanpenner/broccoli-stew/blob/master/lib/env.js#L27 support this environment variable, we should proxy its setting to allow users to use `--environment` and have these packages work OOTB. Given these packages were made by Jo and Stefan, I think setting this env var is a good idea, and allows Brocfile authors to natively support `--environment` without having to refactor their Brocfile.js in order to return a function to support the `options.env` property.

Note, setting `BROCCOLI_ENV` environment variable will *NOT* set the `options.env`.