### PR TITLE
`environment` => `env` in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ module.exports = (options) => {
     // tree = ... assemble tree
 
     // In production environment, minify the files
-    if (options.environment === 'production') {
+    if (options.env === 'production') {
         tree = minify(tree);
     }
 


### PR DESCRIPTION
Code example references undefined key `environment`. Change to `env` to reflect the actual key on the `options` object.