### PR TITLE
Output port in use error if 2 servers started on the same port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -29,14 +29,16 @@ exports.serve = function serve(watcher, host, port, _connect) {
   server.http = http.createServer(server.app);
   server.http.listen(parseInt(port, 10), host);
   server.http.on('error', error => {
-    if (error.code === 'EADDRINUSE') {
-      console.log(`Oh snap 😫. It appears the serve port ${error.port} is already in use on ${error.address}`);
-      console.log(`Are you perhaps already running serve in another terminal window?\n`);
-      process.exit(1);
-      return;
+    if (error.code !== 'EADDRINUSE') {
+      throw error;
     }
-    throw e;
-  })
+
+    console.log(
+      `Oh snap 😫. It appears the serve port ${error.port} is already in use on ${error.address}`
+    );
+    console.log(`Are you perhaps already running serve in another terminal window?\n`);
+    process.exit(1);
+  });
 
   // We register these so the 'exit' handler removing temp dirs is called
   function cleanupAndExit() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,7 +19,7 @@ exports.serve = function serve(watcher, host, port, _connect) {
     cleanupAndExit,
   };
 
-  console.log('Serving on http://' + host + ':' + port + '\n');
+  console.log(`Serving on http://${host}:${port}\n`);
 
   server.watcher = watcher;
   server.builder = server.watcher.builder;
@@ -33,10 +33,10 @@ exports.serve = function serve(watcher, host, port, _connect) {
       throw error;
     }
 
-    console.log(
-      `Oh snap 😫. It appears the serve port ${error.port} is already in use on ${error.address}`
-    );
-    console.log(`Are you perhaps already running serve in another terminal window?\n`);
+    let message = `Oh snap 😫. It appears the serve port http://${host}:${port} is already in use\n`;
+    message += `Are you perhaps already running serve in another terminal window?\n`;
+
+    console.error(message);
     process.exit(1);
   });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -27,6 +27,16 @@ exports.serve = function serve(watcher, host, port, _connect) {
   server.app = connect().use(middleware(server.watcher));
 
   server.http = http.createServer(server.app);
+  server.http.listen(parseInt(port, 10), host);
+  server.http.on('error', error => {
+    if (error.code === 'EADDRINUSE') {
+      console.log(`Oh snap 😫. It appears the serve port ${error.port} is already in use on ${error.address}`);
+      console.log(`Are you perhaps already running serve in another terminal window?\n`);
+      process.exit(1);
+      return;
+    }
+    throw e;
+  })
 
   // We register these so the 'exit' handler removing temp dirs is called
   function cleanupAndExit() {
@@ -52,6 +62,5 @@ exports.serve = function serve(watcher, host, port, _connect) {
     process.exit(1);
   });
 
-  server.http.listen(parseInt(port, 10), host);
   return server;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,7 +33,7 @@ exports.serve = function serve(watcher, host, port, _connect) {
       throw error;
     }
 
-    let message = `Oh snap 😫. It appears the serve port http://${host}:${port} is already in use\n`;
+    let message = `Oh snap 😫. It appears a server is already running on http://${host}:${port}\n`;
     message += `Are you perhaps already running serve in another terminal window?\n`;
 
     console.error(message);

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -64,7 +64,7 @@ describe('server', function() {
   it('errors if port already in use', function() {
     const builder = new Builder(new broccoliSource.WatchedDir('test/fixtures/basic'));
 
-    const invokeServer = (isPrimary) => {
+    const invokeServer = isPrimary => {
       const watcher = new Watcher(builder);
       const svr = Server.serve(watcher, '127.0.0.1', PORT);
       if (isPrimary) {
@@ -81,7 +81,7 @@ describe('server', function() {
             reject(e);
           }
           watcher.quit();
-        }
+        };
       });
     };
 

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -65,7 +65,7 @@ describe('server', function() {
     const builder = new Builder(new broccoliSource.WatchedDir('test/fixtures/basic'));
 
     let errorMessage =
-      `Oh snap 😫. It appears the serve port http://127.0.0.1:${PORT} is already in use\n` +
+      `Oh snap 😫. It appears a server is already running on http://127.0.0.1:${PORT}\n` +
       `Are you perhaps already running serve in another terminal window?\n`;
 
     const consoleMock = sinon.mock(console);

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -91,7 +91,7 @@ describe('server', function() {
       .then(() => {
         chai.expect(exitStub).to.be.calledWith(1);
       });
-  });
+  }).timeout(10000);
 
   it('buildSuccess is handled', function() {
     const builder = new Builder(new broccoliSource.WatchedDir('test/fixtures/basic'));


### PR DESCRIPTION
This has always irritated me, when starting a server when you always have one running, and you get this nasty error:
![image](https://user-images.githubusercontent.com/1246671/55448918-93d2d000-5597-11e9-899e-d670df6dfe6c.png)

So I made it nicer:
![image](https://user-images.githubusercontent.com/1246671/55448841-5ff7aa80-5597-11e9-9884-261a9dd53b56.png)
