### PR TITLE
Memoization in Broccoli

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -212,10 +212,6 @@ module.exports = class Builder extends EventEmitter {
     nodeWrapper.node = node;
     nodeWrapper.label = label;
 
-    // TODO: Is this the best place to do this?
-    // TODO: We would need to warn if a plugin defined a revise method
-    node.revise = () => nodeWrapper.revise();
-
     // Detect cycles
     for (let i = 0; i < _stack.length; i++) {
       if (_stack[i].node === originalNode) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -266,11 +266,11 @@ module.exports = class Builder extends EventEmitter {
         isDirectory = fs.statSync(this.watchedPaths[i].path).isDirectory();
       } catch (err) {
         throw new this.constructor.BuilderError(
-          'Directory not found: ' + this.watchedPaths[i].path
+          `Directory not found: ${this.watchedPaths[i].path}`
         );
       }
       if (!isDirectory) {
-        throw new this.constructor.BuilderError('Not a directory: ' + this.watchedPaths[i].path);
+        throw new this.constructor.BuilderError(`Not a directory: ${this.watchedPaths[i].path}`);
       }
     }
   }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -212,6 +212,10 @@ module.exports = class Builder extends EventEmitter {
     nodeWrapper.node = node;
     nodeWrapper.label = label;
 
+    // TODO: Is this the best place to do this?
+    // TODO: We would need to warn if a plugin defined a revise method
+    node.revise = () => nodeWrapper.revise();
+
     // Detect cycles
     for (let i = 0; i < _stack.length; i++) {
       if (_stack[i].node === originalNode) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -19,6 +19,7 @@ const NodeSetupError = require('./errors/node-setup');
 const BuildError = require('./errors/build');
 const CancelationRequest = require('./cancelation-request');
 const Cancelation = require('./errors/cancelation');
+const logger = require('heimdalljs-logger')('broccoli:builder');
 
 // Clean up left-over temporary directories on uncaught exception.
 tmp.setGracefulCleanup();
@@ -142,6 +143,9 @@ module.exports = class Builder extends EventEmitter {
           this.buildHeimdallTree(outputNodeWrapper);
         }),
       () => {
+        let buildsSkipped = this.nodeWrappers.filter(nw => nw.buildState.built === false).length;
+        logger.debug(`Total nodes skipped: ${buildsSkipped} out of ${this.nodeWrappers.length}`);
+
         this._cancelationRequest = null;
       }
     );

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -239,9 +239,9 @@ module.exports = class Builder extends EventEmitter {
     } else {
       // nodeType === 'source'
       if (nodeInfo.watched) {
-        this.watchedPaths.push({ root: nodeWrapper, path: nodeInfo.sourceDirectory });
+        this.watchedPaths.push(nodeInfo.sourceDirectory);
       } else {
-        this.unwatchedPaths.push({ root: nodeWrapper, path: nodeInfo.sourceDirectory });
+        this.unwatchedPaths.push(nodeInfo.sourceDirectory);
       }
     }
 
@@ -267,14 +267,12 @@ module.exports = class Builder extends EventEmitter {
     for (let i = 0; i < this.watchedPaths.length; i++) {
       let isDirectory;
       try {
-        isDirectory = fs.statSync(this.watchedPaths[i].path).isDirectory();
+        isDirectory = fs.statSync(this.watchedPaths[i]).isDirectory();
       } catch (err) {
-        throw new this.constructor.BuilderError(
-          `Directory not found: ${this.watchedPaths[i].path}`
-        );
+        throw new this.constructor.BuilderError(`Directory not found: ${this.watchedPaths[i]}`);
       }
       if (!isDirectory) {
-        throw new this.constructor.BuilderError(`Not a directory: ${this.watchedPaths[i].path}`);
+        throw new this.constructor.BuilderError(`Not a directory: ${this.watchedPaths[i]}`);
       }
     }
   }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -241,7 +241,7 @@ module.exports = class Builder extends EventEmitter {
       if (nodeInfo.watched) {
         this.watchedPaths.push({ root: nodeWrapper, path: nodeInfo.sourceDirectory });
       } else {
-        this.unwatchedPaths.push(nodeInfo.sourceDirectory);
+        this.unwatchedPaths.push({ root: nodeWrapper, path: nodeInfo.sourceDirectory });
       }
     }
 
@@ -269,7 +269,9 @@ module.exports = class Builder extends EventEmitter {
       try {
         isDirectory = fs.statSync(this.watchedPaths[i].path).isDirectory();
       } catch (err) {
-        throw new this.constructor.BuilderError('Directory not found: ' + this.watchedPaths[i].path);
+        throw new this.constructor.BuilderError(
+          'Directory not found: ' + this.watchedPaths[i].path
+        );
       }
       if (!isDirectory) {
         throw new this.constructor.BuilderError('Not a directory: ' + this.watchedPaths[i].path);

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -228,6 +228,16 @@ module.exports = class Builder extends EventEmitter {
     // record paths.
     let inputNodeWrappers = [];
     if (nodeInfo.nodeType === 'transform') {
+      // TODO: Come up with better connection between wrappers <---> plugins
+      // This is purely a hack to add the "revised" method onto the plugins so they can
+      // call revised whenever they need to indicate that they are not pure.
+      //
+      // This only needs to be applied to transform wrappers as source ones will never call
+      // revised.
+      node.revised = () => { 
+        nodeWrapper._revision++; 
+      };
+  
       const newStack = _stack.concat([nodeWrapper]);
       inputNodeWrappers = nodeInfo.inputNodes.map(inputNode => {
         return this.makeNodeWrapper(inputNode, newStack);
@@ -396,6 +406,28 @@ module.exports = class Builder extends EventEmitter {
 
   get features() {
     return broccoliNodeInfo.features;
+  }
+
+  // This method takes a file that has changed and loops
+  // through all of the watched source nodes and if the file resides
+  // within its directoryPath bump the revision counter.
+  markSourceNodesRevised(filepath) {
+    for (let i = 0; i < this.nodeWrappers.length; i++) {
+      let currentWrapper = this.nodeWrappers[i];
+      let watched = currentWrapper.nodeInfo.watched;
+
+      if (currentWrapper.nodeInfo.nodeType === 'source' && watched) {
+        let root = process.cwd();
+        let ogNode = this.nodeWrappers[i].node._directoryPath;
+        let rel = path.relative(path.join(root, ogNode), filepath);
+
+        // TODO: This is a pretty hacky way to determine if this file is a child
+        // of a node. Come up with a better way to do this.
+        if (!rel.includes('../')) {
+          currentWrapper._revision++;
+        }
+      }
+    }
   }
 };
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -228,16 +228,6 @@ module.exports = class Builder extends EventEmitter {
     // record paths.
     let inputNodeWrappers = [];
     if (nodeInfo.nodeType === 'transform') {
-      // TODO: Come up with better connection between wrappers <---> plugins
-      // This is purely a hack to add the "revised" method onto the plugins so they can
-      // call revised whenever they need to indicate that they are not pure.
-      //
-      // This only needs to be applied to transform wrappers as source ones will never call
-      // revised.
-      node.revised = () => { 
-        nodeWrapper._revision++; 
-      };
-  
       const newStack = _stack.concat([nodeWrapper]);
       inputNodeWrappers = nodeInfo.inputNodes.map(inputNode => {
         return this.makeNodeWrapper(inputNode, newStack);
@@ -245,7 +235,7 @@ module.exports = class Builder extends EventEmitter {
     } else {
       // nodeType === 'source'
       if (nodeInfo.watched) {
-        this.watchedPaths.push(nodeInfo.sourceDirectory);
+        this.watchedPaths.push({ root: nodeWrapper, path: nodeInfo.sourceDirectory });
       } else {
         this.unwatchedPaths.push(nodeInfo.sourceDirectory);
       }
@@ -273,12 +263,12 @@ module.exports = class Builder extends EventEmitter {
     for (let i = 0; i < this.watchedPaths.length; i++) {
       let isDirectory;
       try {
-        isDirectory = fs.statSync(this.watchedPaths[i]).isDirectory();
+        isDirectory = fs.statSync(this.watchedPaths[i].path).isDirectory();
       } catch (err) {
-        throw new this.constructor.BuilderError('Directory not found: ' + this.watchedPaths[i]);
+        throw new this.constructor.BuilderError('Directory not found: ' + this.watchedPaths[i].path);
       }
       if (!isDirectory) {
-        throw new this.constructor.BuilderError('Not a directory: ' + this.watchedPaths[i]);
+        throw new this.constructor.BuilderError('Not a directory: ' + this.watchedPaths[i].path);
       }
     }
   }
@@ -406,28 +396,6 @@ module.exports = class Builder extends EventEmitter {
 
   get features() {
     return broccoliNodeInfo.features;
-  }
-
-  // This method takes a file that has changed and loops
-  // through all of the watched source nodes and if the file resides
-  // within its directoryPath bump the revision counter.
-  markSourceNodesRevised(filepath) {
-    for (let i = 0; i < this.nodeWrappers.length; i++) {
-      let currentWrapper = this.nodeWrappers[i];
-      let watched = currentWrapper.nodeInfo.watched;
-
-      if (currentWrapper.nodeInfo.nodeType === 'source' && watched) {
-        let root = process.cwd();
-        let ogNode = this.nodeWrappers[i].node._directoryPath;
-        let rel = path.relative(path.join(root, ogNode), filepath);
-
-        // TODO: This is a pretty hacky way to determine if this file is a child
-        // of a node. Come up with a better way to do this.
-        if (!rel.includes('../')) {
-          currentWrapper._revision++;
-        }
-      }
-    }
   }
 };
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -269,7 +269,7 @@ module.exports = class Builder extends EventEmitter {
       try {
         isDirectory = fs.statSync(this.watchedPaths[i]).isDirectory();
       } catch (err) {
-        throw new this.constructor.BuilderError('Directory not found: ' +this.watchedPaths[i]);
+        throw new this.constructor.BuilderError('Directory not found: ' + this.watchedPaths[i]);
       }
       if (!isDirectory) {
         throw new this.constructor.BuilderError('Not a directory: ' + this.watchedPaths[i]);

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -269,10 +269,10 @@ module.exports = class Builder extends EventEmitter {
       try {
         isDirectory = fs.statSync(this.watchedPaths[i]).isDirectory();
       } catch (err) {
-        throw new this.constructor.BuilderError(`Directory not found: ${this.watchedPaths[i]}`);
+        throw new this.constructor.BuilderError('Directory not found: ' +this.watchedPaths[i]);
       }
       if (!isDirectory) {
-        throw new this.constructor.BuilderError(`Not a directory: ${this.watchedPaths[i]}`);
+        throw new this.constructor.BuilderError('Not a directory: ' + this.watchedPaths[i]);
       }
     }
   }

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -49,7 +49,7 @@ module.exports = class Watcher extends EventEmitter {
     return this._lifetimeDeferred.promise;
   }
 
-  _change() {
+  _change(filepath) {
     if (!this._ready) {
       logger.debug('change', 'ignored: before ready');
       return;
@@ -59,6 +59,12 @@ module.exports = class Watcher extends EventEmitter {
       return;
     }
     logger.debug('change');
+
+    // Communicate with the builder what file has changed.
+    // TODO: Is this the correct place to invoke this or should be before 
+    // the above checks or even below as apart of the promise chain.
+    this.builder.markSourceNodesRevised(filepath);
+
     this._rebuildScheduled = true;
     // Wait for current build, and ignore build failure
     Promise.resolve(this.currentBuild)

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -49,7 +49,7 @@ module.exports = class Watcher extends EventEmitter {
     return this._lifetimeDeferred.promise;
   }
 
-  _change(watchedRoot) {
+  _change() {
     if (!this._ready) {
       logger.debug('change', 'ignored: before ready');
       return;
@@ -59,11 +59,6 @@ module.exports = class Watcher extends EventEmitter {
       return;
     }
     logger.debug('change');
-
-    // Communicate with the watchedRoot what file has changed.
-    // TODO: Is this the correct place to increment this or should be before 
-    // the above checks or even below as apart of the promise chain.
-    watchedRoot._revision++;
 
     this._rebuildScheduled = true;
     // Wait for current build, and ignore build failure

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -49,7 +49,7 @@ module.exports = class Watcher extends EventEmitter {
     return this._lifetimeDeferred.promise;
   }
 
-  _change(filepath) {
+  _change(watchedRoot) {
     if (!this._ready) {
       logger.debug('change', 'ignored: before ready');
       return;
@@ -60,10 +60,10 @@ module.exports = class Watcher extends EventEmitter {
     }
     logger.debug('change');
 
-    // Communicate with the builder what file has changed.
-    // TODO: Is this the correct place to invoke this or should be before 
+    // Communicate with the watchedRoot what file has changed.
+    // TODO: Is this the correct place to increment this or should be before 
     // the above checks or even below as apart of the promise chain.
-    this.builder.markSourceNodesRevised(filepath);
+    watchedRoot._revision++;
 
     this._rebuildScheduled = true;
     // Wait for current build, and ignore build failure

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -36,7 +36,11 @@ module.exports = class Watcher extends EventEmitter {
     this.watcherAdapter.on('error', this._error.bind(this));
     this.currentBuild = Promise.resolve()
       .then(() => {
-        return this.watcherAdapter.watch(this.builder.watchedPaths);
+        let watchedSourceNodes = this.builder.nodeWrappers.filter(nw => {
+          return nw.nodeInfo.nodeType === 'source' && nw.nodeInfo.watched;
+        });
+
+        return this.watcherAdapter.watch(watchedSourceNodes);
       })
       .then(() => {
         logger.debug('ready');

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -82,12 +82,15 @@ module.exports = class Watcher extends EventEmitter {
   _build() {
     logger.debug('buildStart');
     this.emit('buildStart');
+    const hrstart = process.hrtime();
     const buildPromise = this.builder.build();
     // Trigger change/error events. Importantly, if somebody else chains to
     // currentBuild, their callback will come after our events have
     // triggered, because we registered our callback first.
     buildPromise.then(
       () => {
+        const hrend = process.hrtime(hrstart);
+        logger.debug('Build execution time: %ds %dms', hrend[0], Math.round(hrend[1] / 1e6));
         logger.debug('buildSuccess');
         this.emit('buildSuccess');
       },

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -59,7 +59,6 @@ module.exports = class Watcher extends EventEmitter {
       return;
     }
     logger.debug('change');
-
     this._rebuildScheduled = true;
     // Wait for current build, and ignore build failure
     Promise.resolve(this.currentBuild)

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -8,10 +8,10 @@ function defaultFilterFunction(name) {
   return /^[^.]/.test(name);
 }
 
-function bindFileEvent(adapter, watcher, event) {
+function bindFileEvent(adapter, watcher, watchedRoot, event) {
   watcher.on(event, (filepath, root) => {
     logger.debug(event, root + '/' + filepath);
-    adapter.emit('change', root + '/' + filepath);
+    adapter.emit('change', watchedRoot);
   });
 }
 
@@ -27,12 +27,12 @@ module.exports = class WatcherAdapter extends EventEmitter {
     if (!Array.isArray(watchedPaths)) {
       throw new TypeError(`WatcherAdapter#watch's first argument must be an array of watchedPaths`);
     }
-    let watchers = watchedPaths.map(watchedPath => {
+    let watchers = watchedPaths.map(({ root: watchedRoot, path: watchedPath }) => {
       const watcher = new sane(watchedPath, this.options);
       this.watchers.push(watcher);
-      bindFileEvent(this, watcher, 'change');
-      bindFileEvent(this, watcher, 'add');
-      bindFileEvent(this, watcher, 'delete');
+      bindFileEvent(this, watcher, watchedRoot, 'change');
+      bindFileEvent(this, watcher, watchedRoot, 'add');
+      bindFileEvent(this, watcher, watchedRoot, 'delete');
       return new Promise((resolve, reject) => {
         watcher.on('ready', resolve);
         watcher.on('error', reject);

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -8,11 +8,11 @@ function defaultFilterFunction(name) {
   return /^[^.]/.test(name);
 }
 
-function bindFileEvent(adapter, watcher, watchedNode, event) {
+function bindFileEvent(adapter, watcher, node, event) {
   watcher.on(event, (filepath, root) => {
     logger.debug(event, root + '/' + filepath);
-    logger.debug(`revise called on node [${watchedNode.id}]`);
-    watchedNode.revise();
+    logger.debug(`revise called on node [${node.id}]`);
+    node.revise();
     adapter.emit('change');
   });
 }
@@ -21,20 +21,24 @@ module.exports = class WatcherAdapter extends EventEmitter {
   constructor(options) {
     super();
     this.options = options || {};
+    this.options.watchman = true;
     this.options.filter = this.options.filter || defaultFilterFunction;
     this.watchers = [];
   }
 
-  watch(watchedPaths) {
-    if (!Array.isArray(watchedPaths)) {
-      throw new TypeError(`WatcherAdapter#watch's first argument must be an array of watchedPaths`);
+  watch(watchedSourceNodes) {
+    if (!Array.isArray(watchedSourceNodes)) {
+      throw new TypeError(
+        `WatcherAdapter#watch's first argument must be an array of WatchedDir nodes`
+      );
     }
-    let watchers = watchedPaths.map(({ root: watchedNode, path: watchedPath }) => {
+    let watchers = watchedSourceNodes.map(node => {
+      const watchedPath = node.nodeInfo.sourceDirectory;
       const watcher = new sane(watchedPath, this.options);
       this.watchers.push(watcher);
-      bindFileEvent(this, watcher, watchedNode, 'change');
-      bindFileEvent(this, watcher, watchedNode, 'add');
-      bindFileEvent(this, watcher, watchedNode, 'delete');
+      bindFileEvent(this, watcher, node, 'change');
+      bindFileEvent(this, watcher, node, 'add');
+      bindFileEvent(this, watcher, node, 'delete');
 
       return new Promise((resolve, reject) => {
         watcher.on('ready', resolve);

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -8,10 +8,9 @@ function defaultFilterFunction(name) {
   return /^[^.]/.test(name);
 }
 
-function bindFileEvent(adapter, watcher, watchedRoot, event) {
+function bindFileEvent(adapter, watcher, event) {
   watcher.on(event, (filepath, root) => {
     logger.debug(event, root + '/' + filepath);
-    watchedRoot.revise();
     adapter.emit('change');
   });
 }
@@ -31,9 +30,14 @@ module.exports = class WatcherAdapter extends EventEmitter {
     let watchers = watchedPaths.map(({ root: watchedRoot, path: watchedPath }) => {
       const watcher = new sane(watchedPath, this.options);
       this.watchers.push(watcher);
-      bindFileEvent(this, watcher, watchedRoot, 'change');
-      bindFileEvent(this, watcher, watchedRoot, 'add');
-      bindFileEvent(this, watcher, watchedRoot, 'delete');
+      bindFileEvent(this, watcher, 'change');
+      bindFileEvent(this, watcher, 'add');
+      bindFileEvent(this, watcher, 'delete');
+
+      this.on('change', () => {
+        watchedRoot.revise();
+      });
+
       return new Promise((resolve, reject) => {
         watcher.on('ready', resolve);
         watcher.on('error', reject);

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -21,7 +21,6 @@ module.exports = class WatcherAdapter extends EventEmitter {
   constructor(options) {
     super();
     this.options = options || {};
-    this.options.watchman = true;
     this.options.filter = this.options.filter || defaultFilterFunction;
     this.watchers = [];
   }

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -8,9 +8,10 @@ function defaultFilterFunction(name) {
   return /^[^.]/.test(name);
 }
 
-function bindFileEvent(adapter, watcher, event) {
+function bindFileEvent(adapter, watcher, watchedRoot, event) {
   watcher.on(event, (filepath, root) => {
     logger.debug(event, root + '/' + filepath);
+    watchedRoot.revised();
     adapter.emit('change');
   });
 }
@@ -30,13 +31,9 @@ module.exports = class WatcherAdapter extends EventEmitter {
     let watchers = watchedPaths.map(({ root: watchedRoot, path: watchedPath }) => {
       const watcher = new sane(watchedPath, this.options);
       this.watchers.push(watcher);
-      bindFileEvent(this, watcher, 'change');
-      bindFileEvent(this, watcher, 'add');
-      bindFileEvent(this, watcher, 'delete');
-
-      this.on('change', () => {
-        watchedRoot.revise();
-      });
+      bindFileEvent(this, watcher, watchedRoot, 'change');
+      bindFileEvent(this, watcher, watchedRoot, 'add');
+      bindFileEvent(this, watcher, watchedRoot, 'delete');
 
       return new Promise((resolve, reject) => {
         watcher.on('ready', resolve);

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -11,7 +11,8 @@ function defaultFilterFunction(name) {
 function bindFileEvent(adapter, watcher, watchedRoot, event) {
   watcher.on(event, (filepath, root) => {
     logger.debug(event, root + '/' + filepath);
-    adapter.emit('change', watchedRoot);
+    watchedRoot.revise();
+    adapter.emit('change');
   });
 }
 

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -11,6 +11,7 @@ function defaultFilterFunction(name) {
 function bindFileEvent(adapter, watcher, watchedNode, event) {
   watcher.on(event, (filepath, root) => {
     logger.debug(event, root + '/' + filepath);
+    logger.debug(`revise called on node [${watchedNode.id}]`);
     watchedNode.revise();
     adapter.emit('change');
   });

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -8,10 +8,10 @@ function defaultFilterFunction(name) {
   return /^[^.]/.test(name);
 }
 
-function bindFileEvent(adapter, watcher, watchedRoot, event) {
+function bindFileEvent(adapter, watcher, watchedNode, event) {
   watcher.on(event, (filepath, root) => {
     logger.debug(event, root + '/' + filepath);
-    watchedRoot.revised();
+    watchedNode.revise();
     adapter.emit('change');
   });
 }
@@ -28,12 +28,12 @@ module.exports = class WatcherAdapter extends EventEmitter {
     if (!Array.isArray(watchedPaths)) {
       throw new TypeError(`WatcherAdapter#watch's first argument must be an array of watchedPaths`);
     }
-    let watchers = watchedPaths.map(({ root: watchedRoot, path: watchedPath }) => {
+    let watchers = watchedPaths.map(({ root: watchedNode, path: watchedPath }) => {
       const watcher = new sane(watchedPath, this.options);
       this.watchers.push(watcher);
-      bindFileEvent(this, watcher, watchedRoot, 'change');
-      bindFileEvent(this, watcher, watchedRoot, 'add');
-      bindFileEvent(this, watcher, watchedRoot, 'delete');
+      bindFileEvent(this, watcher, watchedNode, 'change');
+      bindFileEvent(this, watcher, watchedNode, 'add');
+      bindFileEvent(this, watcher, watchedNode, 'delete');
 
       return new Promise((resolve, reject) => {
         watcher.on('ready', resolve);

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -11,7 +11,7 @@ function defaultFilterFunction(name) {
 function bindFileEvent(adapter, watcher, event) {
   watcher.on(event, (filepath, root) => {
     logger.debug(event, root + '/' + filepath);
-    adapter.emit('change');
+    adapter.emit('change', root + '/' + filepath);
   });
 }
 

--- a/lib/wrappers/node.js
+++ b/lib/wrappers/node.js
@@ -8,7 +8,7 @@ module.exports = class NodeWrapper {
     this._revision = 0;
   }
 
-  revised() {
+  revise() {
     this._revision++;
   }
 

--- a/lib/wrappers/node.js
+++ b/lib/wrappers/node.js
@@ -5,7 +5,6 @@ const undefinedToNull = require('../utils/undefined-to-null');
 module.exports = class NodeWrapper {
   constructor() {
     this.buildState = {};
-    this._revision = 0;
   }
 
   toJSON() {

--- a/lib/wrappers/node.js
+++ b/lib/wrappers/node.js
@@ -5,6 +5,7 @@ const undefinedToNull = require('../utils/undefined-to-null');
 module.exports = class NodeWrapper {
   constructor() {
     this.buildState = {};
+    this._revision = 0;
   }
 
   toJSON() {

--- a/lib/wrappers/node.js
+++ b/lib/wrappers/node.js
@@ -8,7 +8,7 @@ module.exports = class NodeWrapper {
     this._revision = 0;
   }
 
-  revise() {
+  revised() {
     this._revision++;
   }
 

--- a/lib/wrappers/node.js
+++ b/lib/wrappers/node.js
@@ -5,6 +5,15 @@ const undefinedToNull = require('../utils/undefined-to-null');
 module.exports = class NodeWrapper {
   constructor() {
     this.buildState = {};
+    this._revision = 0;
+  }
+
+  revise() {
+    this._revision++;
+  }
+
+  get revision() {
+    return this._revision;
   }
 
   toJSON() {

--- a/lib/wrappers/source-node.js
+++ b/lib/wrappers/source-node.js
@@ -4,7 +4,9 @@ const fs = require('fs');
 const undefinedToNull = require('../utils/undefined-to-null');
 
 module.exports = class SourceNodeWrapper extends NodeWrapper {
-  setup(/* features */) {}
+  setup(/* features */) {
+    this._revision = 0; // TODO: this feels a little weird that source and transform are different
+  }
   build() {
     // We only check here that the sourceDirectory exists and is a directory
     try {

--- a/lib/wrappers/source-node.js
+++ b/lib/wrappers/source-node.js
@@ -4,9 +4,7 @@ const fs = require('fs');
 const undefinedToNull = require('../utils/undefined-to-null');
 
 module.exports = class SourceNodeWrapper extends NodeWrapper {
-  setup(/* features */) {
-    this._revision = 0; // TODO: this feels a little weird that source and transform are different
-  }
+  setup(/* features */) {}
   build() {
     // We only check here that the sourceDirectory exists and is a directory
     try {

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -14,9 +14,6 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       cachePath: this.cachePath,
     });
     this.callbackObject = this.nodeInfo.getCallbackObject();
-    this.callbackObject.revised = () => {
-      this.revised();
-    };
 
     // This weakmap holds references from inputNode --> last known revision #
     // If the any inputNode's ref does not match what is stored in here then we
@@ -24,13 +21,17 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     this.inputRevisions = new WeakMap();
   }
 
-  // Memoization is currently optin via either BROCCOLI_VOLATILE = true or
-  // by a plugin specifing that they are volatile
-  memoizationEnabled(volatile) {
-    return volatile || process.env.BROCCOLI_VOLATILE === 'true';
-  }
-
   shouldBuild() {
+    // The plugin has told us they should always build
+    if (this.nodeInfo.volatile === true) {
+      return true;
+    }
+
+    // Memoization is currently optin via BROCCOLI_ENABLED_VOLATILE = true
+    if (process.env.BROCCOLI_ENABLED_VOLATILE !== 'true') {
+      return true;
+    }
+
     // The plugin has no input nodes so it's build method should not
     // be called after the first build
     if (this.inputNodeWrappers.length === 0 && this.revision === 0) {
@@ -60,13 +61,9 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     return new Promise(resolve => {
       startTime = process.hrtime();
 
-      if (this.memoizationEnabled(this.nodeInfo.volatile)) {
-        let shouldBuild = this.shouldBuild();
-
-        if (!shouldBuild) {
-          this.buildState.built = false;
-          return resolve(); // Noop the build since inputs did not change
-        }
+      if (!this.shouldBuild()) {
+        this.buildState.built = false;
+        return resolve(); // Noop the build since inputs did not change
       }
 
       if (!this.nodeInfo.persistentOutput) {
@@ -76,10 +73,7 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
 
       resolve(this.callbackObject.build());
 
-      // If the plugin is volatile then it will be responsible for calling revise.
-      if (!this.nodeInfo.volatile) {
-        this.revise();
-      }
+      this.revise();
     }).then(() => {
       const now = process.hrtime();
       const endTime = process.hrtime(startTime);

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -24,6 +24,12 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     this.inputRevisions = new WeakMap();
   }
 
+  // Memoization is currently optin via either BROCCOLI_VOLATILE = true or
+  // by a plugin specifing that they are volatile
+  memoizationEnabled(volatile) {
+    return volatile || process.env.BROCCOLI_VOLATILE === 'true';
+  }
+
   shouldBuild() {
     let shouldBuild = false;
 
@@ -50,13 +56,14 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     return new Promise(resolve => {
       startTime = process.hrtime();
 
-      if (this.nodeInfo.memoize === true || this.nodeInfo.memoize === 'custom') {
+      if (this.memoizationEnabled(this.nodeInfo.volatile)) {
         let shouldBuild = this.shouldBuild();
 
         if (!shouldBuild) {
           logger.debug(
             `${this.toString()}'s inputNodes have not been revised. Skipping building this node.`
           );
+
           return resolve(); // Noop the build since inputs did not change
         }
       }
@@ -68,10 +75,9 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
 
       resolve(this.callbackObject.build());
 
-      // if memoization is set to custom then the plugin will be in charge of
-      // telling us if they have been revised
-      if (this.nodeInfo.memoize !== 'custom') {
-        this.revised();
+      // If the plugin is volatile then it will be responsible for calling revise.
+      if (!this.nodeInfo.volatile) {
+        this.revise();
       }
     }).then(() => {
       const now = process.hrtime();

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -4,7 +4,7 @@ const NodeWrapper = require('./node');
 const fs = require('fs');
 const undefinedToNull = require('../utils/undefined-to-null');
 const rimraf = require('rimraf');
-const logger = require('heimdalljs-logger')('broccoli:wrappers:transform-node');
+const logger = require('heimdalljs-logger')('broccoli:transform-node');
 
 module.exports = class TransformNodeWrapper extends NodeWrapper {
   setup(features) {
@@ -31,23 +31,27 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
   }
 
   shouldBuild() {
-    let shouldBuild = false;
-
     // The plugin has no input nodes so it's build method should not
     // be called after the first build
-    if (this.inputNodeWrappers.length === 0 && this.revision > 0) {
-      return false;
+    if (this.inputNodeWrappers.length === 0 && this.revision === 0) {
+      return true;
     }
 
+    let nodesThatChanged = [];
     this.inputNodeWrappers.forEach(wrapper => {
       if (this.inputRevisions.get(wrapper) !== wrapper.revision) {
-        logger.debug(`${wrapper.toString()} has been revised since last build.`);
-        shouldBuild = true;
+        nodesThatChanged.push(wrapper.id);
         this.inputRevisions.set(wrapper, wrapper.revision);
       }
     });
 
-    return shouldBuild;
+    if (nodesThatChanged.length > 0) {
+      logger.debug(`${this.id} built because inputNodes [${nodesThatChanged.join(', ')}] changed`);
+
+      return true;
+    }
+
+    return false;
   }
 
   build() {
@@ -60,10 +64,7 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
         let shouldBuild = this.shouldBuild();
 
         if (!shouldBuild) {
-          logger.debug(
-            `${this.toString()}'s inputNodes have not been revised. Skipping building this node.`
-          );
-
+          this.buildState.built = false;
           return resolve(); // Noop the build since inputs did not change
         }
       }
@@ -81,12 +82,21 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       }
     }).then(() => {
       const now = process.hrtime();
+      const endTime = process.hrtime(startTime);
 
       // Build time in milliseconds
       this.buildState.selfTime = 1000 * (now[0] - startTime[0] + (now[1] - startTime[1]) / 1e9);
       this.buildState.totalTime = this.buildState.selfTime;
       for (let i = 0; i < this.inputNodeWrappers.length; i++) {
         this.buildState.totalTime += this.inputNodeWrappers[i].buildState.totalTime;
+      }
+
+      if (this.buildState.selfTime >= 100) {
+        logger.debug(
+          `Node build execution time: %ds %dms`,
+          endTime[0],
+          Math.round(endTime[1] / 1e6)
+        );
       }
     });
   }

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -30,15 +30,22 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       // work without overriding __broccoliGetInfo__ at the plugin layer
       if (this.nodeInfo.sideEffectFree) {
         let shouldBuild = false;
-        for (let i = 0; i < this.inputNodeWrappers.length; i++) {
-          let inputRev = this.inputNodeWrappers[i]._revision;
-          let currentRev = this.inputNodeWrappersRefCounters.get(this.inputNodeWrappers[i]);
-
-          if (currentRev !== inputRev) {
-            shouldBuild = true;
-            this.inputNodeWrappersRefCounters.set(this.inputNodeWrappers[i], inputRev);
+        this.inputNodeWrappers.forEach(wrapper => {
+          let inputRev;
+          
+          // TODO: this doesnt "feel" right having the revision count kept at different locations
+          // depending on if you are a source or transform node.
+          if (wrapper.nodeInfo.nodeType === 'source') {
+            inputRev = wrapper._revision;
+          } else {
+            inputRev = wrapper.callbackObject._revision || 0;
           }
-        }
+
+          if (this.inputNodeWrappersRefCounters.get(wrapper) !== inputRev) {
+            shouldBuild = true;
+            this.inputNodeWrappersRefCounters.set(wrapper, inputRev);
+          }
+        });
 
         if (!shouldBuild) {
           return resolve(); // Noop the build since inputs did not change

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -13,6 +13,11 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       cachePath: this.cachePath,
     });
     this.callbackObject = this.nodeInfo.getCallbackObject();
+
+    // This weakmap holds references from inputNode --> last known revision #
+    // If the any inputNode's ref does not match what is stored in here then we
+    // know a modification has happened so we call the build method
+    this.inputNodeWrappersRefCounters = new WeakMap();
   }
 
   build() {
@@ -21,7 +26,28 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     return new Promise(resolve => {
       startTime = process.hrtime();
 
-      if (!this.nodeInfo.persistentOutput) {
+      // TODO: "sideEffectFree" needs to be added to broccoli/broccoli-node-info for this to 
+      // work without overriding __broccoliGetInfo__ at the plugin layer
+      if (this.nodeInfo.sideEffectFree) {
+        let shouldBuild = false;
+        for (let i = 0; i < this.inputNodeWrappers.length; i++) {
+          let inputRev = this.inputNodeWrappers[i]._revision;
+          let currentRev = this.inputNodeWrappersRefCounters.get(this.inputNodeWrappers[i]);
+
+          if (currentRev !== inputRev) {
+            shouldBuild = true;
+            this.inputNodeWrappersRefCounters.set(this.inputNodeWrappers[i], inputRev);
+          }
+        }
+
+        if (!shouldBuild) {
+          return resolve(); // Noop the build since inputs did not change
+        }
+      }
+
+      // Do not remove the output if side effect is 
+      // TODO: throw an error if persistentOuput is false and sideEffectFree is true
+      if (!this.nodeInfo.persistentOutput && !this.nodeInfo.sideEffectFree) {
         rimraf.sync(this.outputPath);
         fs.mkdirSync(this.outputPath);
       }

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -27,8 +27,8 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       return true;
     }
 
-    // Memoization is currently optin via BROCCOLI_ENABLED_VOLATILE = true
-    if (process.env.BROCCOLI_ENABLED_VOLATILE !== 'true') {
+    // Memoization is currently optin via BROCCOLI_ENABLED_MEMOIZE = true
+    if (process.env.BROCCOLI_ENABLED_MEMOIZE !== 'true') {
       return true;
     }
 

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -21,7 +21,21 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     // This weakmap holds references from inputNode --> last known revision #
     // If the any inputNode's ref does not match what is stored in here then we
     // know a modification has happened so we call the build method
-    this.lastRevisions = new WeakMap();
+    this.inputRevisions = new WeakMap();
+  }
+
+  shouldBuild() {
+    let shouldBuild = false;
+
+    this.inputNodeWrappers.forEach(wrapper => {
+      if (this.inputRevisions.get(wrapper) !== wrapper.revision) {
+        logger.debug(`${wrapper.toString()} has been revised since last build.`);
+        shouldBuild = true;
+        this.inputRevisions.set(wrapper, wrapper.revision);
+      }
+    });
+
+    return shouldBuild;
   }
 
   build() {
@@ -30,17 +44,8 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     return new Promise(resolve => {
       startTime = process.hrtime();
 
-      // TODO: "sideEffectFree" needs to be added to broccoli/broccoli-node-info for this to
-      // work without overriding __broccoliGetInfo__ at the plugin layer
       if (this.nodeInfo.sideEffectFree) {
-        let shouldBuild = false;
-        this.inputNodeWrappers.forEach(wrapper => {
-          if (this.lastRevisions.get(wrapper) !== wrapper.revision) {
-            logger.debug(`${wrapper.toString()} has been revised since last build.`);
-            shouldBuild = true;
-            this.lastRevisions.set(wrapper, wrapper.revision);
-          }
-        });
+        let shouldBuild = this.shouldBuild();
 
         if (!shouldBuild) {
           logger.debug(
@@ -50,8 +55,6 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
         }
       }
 
-      // Do not remove the output if side effect is
-      // TODO: throw an error if persistentOuput is false and sideEffectFree is true
       if (!this.nodeInfo.persistentOutput && !this.nodeInfo.sideEffectFree) {
         rimraf.sync(this.outputPath);
         fs.mkdirSync(this.outputPath);
@@ -60,6 +63,11 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       resolve(this.callbackObject.build());
     }).then(() => {
       const now = process.hrtime();
+
+      if (this.nodeInfo.sideEffectFree) {
+        this.revise();
+      }
+
       // Build time in milliseconds
       this.buildState.selfTime = 1000 * (now[0] - startTime[0] + (now[1] - startTime[1]) / 1e9);
       this.buildState.totalTime = this.buildState.selfTime;

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -14,8 +14,8 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       cachePath: this.cachePath,
     });
     this.callbackObject = this.nodeInfo.getCallbackObject();
-    this.callbackObject.revise = () => {
-      this.revise();
+    this.callbackObject.revised = () => {
+      this.revised();
     };
 
     // This weakmap holds references from inputNode --> last known revision #
@@ -26,6 +26,12 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
 
   shouldBuild() {
     let shouldBuild = false;
+
+    // The plugin has no input nodes so it's build method should not
+    // be called after the first build
+    if (this.inputNodeWrappers.length === 0 && this.revision > 0) {
+      return false;
+    }
 
     this.inputNodeWrappers.forEach(wrapper => {
       if (this.inputRevisions.get(wrapper) !== wrapper.revision) {
@@ -44,7 +50,7 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     return new Promise(resolve => {
       startTime = process.hrtime();
 
-      if (this.nodeInfo.sideEffectFree) {
+      if (this.nodeInfo.memoize === true || this.nodeInfo.memoize === 'custom') {
         let shouldBuild = this.shouldBuild();
 
         if (!shouldBuild) {
@@ -55,18 +61,20 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
         }
       }
 
-      if (!this.nodeInfo.persistentOutput && !this.nodeInfo.sideEffectFree) {
+      if (!this.nodeInfo.persistentOutput) {
         rimraf.sync(this.outputPath);
         fs.mkdirSync(this.outputPath);
       }
 
       resolve(this.callbackObject.build());
+
+      // if memoization is set to custom then the plugin will be in charge of
+      // telling us if they have been revised
+      if (this.nodeInfo.memoize !== 'custom') {
+        this.revised();
+      }
     }).then(() => {
       const now = process.hrtime();
-
-      if (this.nodeInfo.sideEffectFree) {
-        this.revise();
-      }
 
       // Build time in milliseconds
       this.buildState.selfTime = 1000 * (now[0] - startTime[0] + (now[1] - startTime[1]) / 1e9);

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -4,6 +4,7 @@ const NodeWrapper = require('./node');
 const fs = require('fs');
 const undefinedToNull = require('../utils/undefined-to-null');
 const rimraf = require('rimraf');
+const logger = require('heimdalljs-logger')('broccoli:wrappers:transform-node');
 
 module.exports = class TransformNodeWrapper extends NodeWrapper {
   setup(features) {
@@ -17,7 +18,7 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     // This weakmap holds references from inputNode --> last known revision #
     // If the any inputNode's ref does not match what is stored in here then we
     // know a modification has happened so we call the build method
-    this.inputNodeWrappersRefCounters = new WeakMap();
+    this.lastRevisions = new WeakMap();
   }
 
   build() {
@@ -31,23 +32,15 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       if (this.nodeInfo.sideEffectFree) {
         let shouldBuild = false;
         this.inputNodeWrappers.forEach(wrapper => {
-          let inputRev;
-          
-          // TODO: this doesnt "feel" right having the revision count kept at different locations
-          // depending on if you are a source or transform node.
-          if (wrapper.nodeInfo.nodeType === 'source') {
-            inputRev = wrapper._revision;
-          } else {
-            inputRev = wrapper.callbackObject._revision || 0;
-          }
-
-          if (this.inputNodeWrappersRefCounters.get(wrapper) !== inputRev) {
+          if (this.lastRevisions.get(wrapper) !== wrapper.revision) {
+            logger.debug(`${wrapper.toString()} has been revised since last build.`);
             shouldBuild = true;
-            this.inputNodeWrappersRefCounters.set(wrapper, inputRev);
+            this.lastRevisions.set(wrapper, wrapper.revision);
           }
         });
 
         if (!shouldBuild) {
+          logger.debug(`${this.toString()}'s inputNodes have not been revised. Skipping building this node.`);
           return resolve(); // Noop the build since inputs did not change
         }
       }

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -27,7 +27,7 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     return new Promise(resolve => {
       startTime = process.hrtime();
 
-      // TODO: "sideEffectFree" needs to be added to broccoli/broccoli-node-info for this to 
+      // TODO: "sideEffectFree" needs to be added to broccoli/broccoli-node-info for this to
       // work without overriding __broccoliGetInfo__ at the plugin layer
       if (this.nodeInfo.sideEffectFree) {
         let shouldBuild = false;
@@ -40,12 +40,14 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
         });
 
         if (!shouldBuild) {
-          logger.debug(`${this.toString()}'s inputNodes have not been revised. Skipping building this node.`);
+          logger.debug(
+            `${this.toString()}'s inputNodes have not been revised. Skipping building this node.`
+          );
           return resolve(); // Noop the build since inputs did not change
         }
       }
 
-      // Do not remove the output if side effect is 
+      // Do not remove the output if side effect is
       // TODO: throw an error if persistentOuput is false and sideEffectFree is true
       if (!this.nodeInfo.persistentOutput && !this.nodeInfo.sideEffectFree) {
         rimraf.sync(this.outputPath);

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -14,6 +14,9 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       cachePath: this.cachePath,
     });
     this.callbackObject = this.nodeInfo.getCallbackObject();
+    this.callbackObject.revise = () => {
+      this.revise();
+    };
 
     // This weakmap holds references from inputNode --> last known revision #
     // If the any inputNode's ref does not match what is stored in here then we

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -255,7 +255,9 @@ describe('Builder', function() {
           builder = new FixtureBuilder(new broccoliSource.UnwatchedDir('test/fixtures/basic'));
 
           expect(builder.watchedPaths).to.deep.equal([]);
-          expect(builder.unwatchedPaths).to.deep.equal(['test/fixtures/basic']);
+          expect(builder.unwatchedPaths.map(paths => paths.path)).to.deep.equal([
+            'test/fixtures/basic',
+          ]);
 
           return expect(builder.build()).to.eventually.deep.equal({
             'foo.txt': 'OK',
@@ -265,7 +267,9 @@ describe('Builder', function() {
         it('records watched source directories', function() {
           builder = new FixtureBuilder(new broccoliSource.WatchedDir('test/fixtures/basic'));
 
-          expect(builder.watchedPaths).to.deep.equal(['test/fixtures/basic']);
+          expect(builder.watchedPaths.map(paths => paths.path)).to.deep.equal([
+            'test/fixtures/basic',
+          ]);
           expect(builder.unwatchedPaths).to.deep.equal([]);
 
           return expect(builder.build()).to.eventually.deep.equal({
@@ -278,7 +282,7 @@ describe('Builder', function() {
     it('records string (watched) source directories', function() {
       builder = new FixtureBuilder('test/fixtures/basic');
 
-      expect(builder.watchedPaths).to.deep.equal(['test/fixtures/basic']);
+      expect(builder.watchedPaths.map(paths => paths.path)).to.deep.equal(['test/fixtures/basic']);
       expect(builder.unwatchedPaths).to.deep.equal([]);
 
       return expect(builder.build()).to.eventually.deep.equal({
@@ -291,7 +295,7 @@ describe('Builder', function() {
 
       builder = new FixtureBuilder(new plugins.Merge([src, src]));
 
-      expect(builder.watchedPaths).to.deep.equal(['test/fixtures/basic']);
+      expect(builder.watchedPaths.map(paths => paths.path)).to.deep.equal(['test/fixtures/basic']);
     });
 
     it("fails construction when a watched source directory doesn't exist", function() {

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -92,6 +92,10 @@ describe('Builder', function() {
       const plugins = makePlugins(Plugin);
 
       describe('broccoli-plugin ' + version, function() {
+        afterEach(() => {
+          delete process.env['BROCCOLI_VOLATILE'];
+        });
+
         it('builds a single node, repeatedly', function() {
           const node = new plugins.Veggies();
           const buildSpy = sinon.spy(node, 'build');
@@ -147,21 +151,22 @@ describe('Builder', function() {
         });
 
         it('only builds if revision counter has incremented', function() {
-          const outputNode = new plugins.Merge(
-            [
-              new broccoliSource.WatchedDir('test/fixtures/basic'),
-              new broccoliSource.WatchedDir('test/fixtures/public'),
-            ],
-            { memoize: true }
-          );
+          process.env['BROCCOLI_VOLATILE'] = true;
+
+          const outputNode = new plugins.Merge([
+            new broccoliSource.WatchedDir('test/fixtures/basic'),
+            new broccoliSource.WatchedDir('test/fixtures/public'),
+          ]);
+
           const buildSpy = sinon.spy(outputNode, 'build');
 
           builder = new FixtureBuilder(outputNode);
-          builder.nodeWrappers.forEach(wrap => (wrap.nodeInfo.memoize = true));
 
           return builder
             .build()
             .then(() => {
+              expect(buildSpy).to.have.been.calledOnce;
+
               // Now we simulate a rebuild (and the revisions have not changed)
               return builder.build();
             })
@@ -171,35 +176,30 @@ describe('Builder', function() {
         });
 
         it('only nodes with inputs that have different revisions call their builds', function() {
+          process.env['BROCCOLI_VOLATILE'] = true;
+
           const basicWatchDir = new broccoliSource.WatchedDir('test/fixtures/basic');
           const publicWatchDir = new broccoliSource.WatchedDir('test/fixtures/public');
 
-          const fooNode = new plugins.Merge([basicWatchDir], {
-            memoize: true,
-            overwrite: true,
-          });
-          const barNode = new plugins.Merge([publicWatchDir], {
-            memoize: true,
-            overwrite: true,
-          });
-          const outputNode = new plugins.Merge([fooNode, barNode], {
-            memoize: true,
-            overwrite: true,
-          });
+          const fooNode = new plugins.Merge([basicWatchDir], { overwrite: true });
+          const barNode = new plugins.Merge([publicWatchDir], { overwrite: true });
+          const outputNode = new plugins.Merge([fooNode, barNode], { overwrite: true });
           const fooBuildSpy = sinon.spy(fooNode, 'build');
           const barBuildSpy = sinon.spy(barNode, 'build');
           const buildSpy = sinon.spy(outputNode, 'build');
 
           builder = new FixtureBuilder(outputNode);
-          builder.nodeWrappers.forEach(wrap => (wrap.nodeInfo.memoize = true));
 
           return builder
             .build()
             .then(() => {
+              expect(fooBuildSpy).to.have.been.calledOnce;
+              expect(barBuildSpy).to.have.been.calledOnce;
+              expect(buildSpy).to.have.been.calledOnce;
+
               // Now we simulate a rebuild (and the revisions have not changed)
-              builder.nodeWrappers
-                .find(wrap => wrap.outputPath === 'test/fixtures/basic')
-                .revised();
+              builder.nodeWrappers.find(wrap => wrap.outputPath === 'test/fixtures/basic').revise();
+
               return builder.build();
             })
             .then(() => {

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -93,7 +93,7 @@ describe('Builder', function() {
 
       describe('broccoli-plugin ' + version, function() {
         afterEach(() => {
-          delete process.env['BROCCOLI_VOLATILE'];
+          delete process.env['BROCCOLI_ENABLED_VOLATILE'];
         });
 
         it('builds a single node, repeatedly', function() {
@@ -150,8 +150,8 @@ describe('Builder', function() {
             });
         });
 
-        it('only builds if revision counter has incremented', function() {
-          process.env['BROCCOLI_VOLATILE'] = true;
+        it('builds if revision counter has incremented', function() {
+          process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
 
           const outputNode = new plugins.Merge([
             new broccoliSource.WatchedDir('test/fixtures/basic'),
@@ -175,8 +175,8 @@ describe('Builder', function() {
             });
         });
 
-        it('only nodes with inputs that have different revisions call their builds', function() {
-          process.env['BROCCOLI_VOLATILE'] = true;
+        it('nodes with inputs that have different revisions call their builds', function() {
+          process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
 
           const basicWatchDir = new broccoliSource.WatchedDir('test/fixtures/basic');
           const publicWatchDir = new broccoliSource.WatchedDir('test/fixtures/public');
@@ -318,9 +318,7 @@ describe('Builder', function() {
           builder = new FixtureBuilder(new broccoliSource.UnwatchedDir('test/fixtures/basic'));
 
           expect(builder.watchedPaths).to.deep.equal([]);
-          expect(builder.unwatchedPaths.map(paths => paths.path)).to.deep.equal([
-            'test/fixtures/basic',
-          ]);
+          expect(builder.unwatchedPaths).to.deep.equal(['test/fixtures/basic']);
 
           return expect(builder.build()).to.eventually.deep.equal({
             'foo.txt': 'OK',
@@ -330,9 +328,7 @@ describe('Builder', function() {
         it('records watched source directories', function() {
           builder = new FixtureBuilder(new broccoliSource.WatchedDir('test/fixtures/basic'));
 
-          expect(builder.watchedPaths.map(paths => paths.path)).to.deep.equal([
-            'test/fixtures/basic',
-          ]);
+          expect(builder.watchedPaths).to.deep.equal(['test/fixtures/basic']);
           expect(builder.unwatchedPaths).to.deep.equal([]);
 
           return expect(builder.build()).to.eventually.deep.equal({
@@ -345,7 +341,7 @@ describe('Builder', function() {
     it('records string (watched) source directories', function() {
       builder = new FixtureBuilder('test/fixtures/basic');
 
-      expect(builder.watchedPaths.map(paths => paths.path)).to.deep.equal(['test/fixtures/basic']);
+      expect(builder.watchedPaths).to.deep.equal(['test/fixtures/basic']);
       expect(builder.unwatchedPaths).to.deep.equal([]);
 
       return expect(builder.build()).to.eventually.deep.equal({
@@ -358,7 +354,7 @@ describe('Builder', function() {
 
       builder = new FixtureBuilder(new plugins.Merge([src, src]));
 
-      expect(builder.watchedPaths.map(paths => paths.path)).to.deep.equal(['test/fixtures/basic']);
+      expect(builder.watchedPaths).to.deep.equal(['test/fixtures/basic']);
     });
 
     it("fails construction when a watched source directory doesn't exist", function() {

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -93,7 +93,7 @@ describe('Builder', function() {
 
       describe('broccoli-plugin ' + version, function() {
         afterEach(() => {
-          delete process.env['BROCCOLI_ENABLED_VOLATILE'];
+          delete process.env['BROCCOLI_ENABLED_MEMOIZE'];
         });
 
         it('builds a single node, repeatedly', function() {
@@ -151,7 +151,7 @@ describe('Builder', function() {
         });
 
         it('builds if revision counter has incremented', function() {
-          process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
+          process.env['BROCCOLI_ENABLED_MEMOIZE'] = true;
 
           const outputNode = new plugins.Merge([
             new broccoliSource.WatchedDir('test/fixtures/basic'),
@@ -176,7 +176,7 @@ describe('Builder', function() {
         });
 
         it('nodes with inputs that have different revisions call their builds', function() {
-          process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
+          process.env['BROCCOLI_ENABLED_MEMOIZE'] = true;
 
           const basicWatchDir = new broccoliSource.WatchedDir('test/fixtures/basic');
           const publicWatchDir = new broccoliSource.WatchedDir('test/fixtures/public');

--- a/test/watch_adapter_test.js
+++ b/test/watch_adapter_test.js
@@ -27,23 +27,23 @@ describe('WatcherAdapter', function() {
     };
 
     const watchRoot = {
-      revised() {},
+      revise() {},
     };
 
     it('works', function() {
       const trigger = sinon.spy(adapter, 'emit');
       const on = sinon.spy(watcher, 'on');
-      const revised = sinon.spy(watchRoot, 'revised');
+      const revise = sinon.spy(watchRoot, 'revise');
 
       expect(on).to.have.not.been.called;
       expect(trigger).to.have.not.been.called;
-      expect(revised).to.have.not.been.called;
+      expect(revise).to.have.not.been.called;
 
       bindFileEvent(adapter, watcher, watchRoot, 'change');
 
       expect(on).to.have.been.calledOnce;
       expect(trigger).to.have.been.calledOnce;
-      expect(revised).to.have.been.calledOnce;
+      expect(revise).to.have.been.calledOnce;
       expect(on).to.have.been.calledWith('change');
       expect(trigger).to.have.been.calledWith('change');
 
@@ -51,7 +51,7 @@ describe('WatcherAdapter', function() {
 
       expect(on).to.have.been.calledTwice;
       expect(trigger).to.have.been.calledTwice;
-      expect(revised).to.have.been.calledTwice;
+      expect(revise).to.have.been.calledTwice;
       expect(on).to.have.been.calledWith('add');
       expect(trigger).to.have.been.calledWith('change');
 
@@ -59,7 +59,7 @@ describe('WatcherAdapter', function() {
 
       expect(on).to.have.been.calledThrice;
       expect(trigger).to.have.been.calledThrice;
-      expect(revised).to.have.been.calledThrice;
+      expect(revise).to.have.been.calledThrice;
       expect(on).to.have.been.calledWith('remove');
       expect(trigger).to.have.been.calledWith('change');
     });
@@ -103,7 +103,7 @@ describe('WatcherAdapter', function() {
     let adapter;
 
     const watchRoot = {
-      revised() {},
+      revise() {},
     };
 
     afterEach(function() {

--- a/test/watch_adapter_test.js
+++ b/test/watch_adapter_test.js
@@ -93,6 +93,10 @@ describe('WatcherAdapter', function() {
     const FIXTURE_PROJECT = __dirname + '/fixtures/project';
     let adapter;
 
+    const watchRoot = {
+      revise() {},
+    };
+
     afterEach(function() {
       adapter.quit();
     });
@@ -127,7 +131,7 @@ describe('WatcherAdapter', function() {
       expect(trigger).to.have.callCount(0);
 
       expect(adapter.watchers.length).to.eql(0);
-      let watching = adapter.watch([FIXTURE_BASIC]);
+      let watching = adapter.watch([{ path: FIXTURE_BASIC, root: watchRoot }]);
 
       expect(adapter.watchers.length).to.eql(1);
 
@@ -145,7 +149,7 @@ describe('WatcherAdapter', function() {
           trigger.resetHistory();
 
           // this time also watch the FIXTURE_PROJECT
-          let watching = adapter.watch([FIXTURE_PROJECT]);
+          let watching = adapter.watch([{ path: FIXTURE_PROJECT, root: watchRoot }]);
           expect(adapter.watchers.length).to.eql(2);
 
           return watching.then(val => {

--- a/test/watch_adapter_test.js
+++ b/test/watch_adapter_test.js
@@ -26,31 +26,40 @@ describe('WatcherAdapter', function() {
       },
     };
 
+    const watchRoot = {
+      revised() {},
+    };
+
     it('works', function() {
       const trigger = sinon.spy(adapter, 'emit');
       const on = sinon.spy(watcher, 'on');
+      const revised = sinon.spy(watchRoot, 'revised');
 
       expect(on).to.have.not.been.called;
       expect(trigger).to.have.not.been.called;
+      expect(revised).to.have.not.been.called;
 
-      bindFileEvent(adapter, watcher, 'change');
+      bindFileEvent(adapter, watcher, watchRoot, 'change');
 
       expect(on).to.have.been.calledOnce;
       expect(trigger).to.have.been.calledOnce;
+      expect(revised).to.have.been.calledOnce;
       expect(on).to.have.been.calledWith('change');
       expect(trigger).to.have.been.calledWith('change');
 
-      bindFileEvent(adapter, watcher, 'add');
+      bindFileEvent(adapter, watcher, watchRoot, 'add');
 
       expect(on).to.have.been.calledTwice;
       expect(trigger).to.have.been.calledTwice;
+      expect(revised).to.have.been.calledTwice;
       expect(on).to.have.been.calledWith('add');
       expect(trigger).to.have.been.calledWith('change');
 
-      bindFileEvent(adapter, watcher, 'remove');
+      bindFileEvent(adapter, watcher, watchRoot, 'remove');
 
       expect(on).to.have.been.calledThrice;
       expect(trigger).to.have.been.calledThrice;
+      expect(revised).to.have.been.calledThrice;
       expect(on).to.have.been.calledWith('remove');
       expect(trigger).to.have.been.calledWith('change');
     });
@@ -94,7 +103,7 @@ describe('WatcherAdapter', function() {
     let adapter;
 
     const watchRoot = {
-      revise() {},
+      revised() {},
     };
 
     afterEach(function() {

--- a/test/watch_adapter_test.js
+++ b/test/watch_adapter_test.js
@@ -26,20 +26,20 @@ describe('WatcherAdapter', function() {
       },
     };
 
-    const watchRoot = {
+    const watchedNode = {
       revise() {},
     };
 
     it('works', function() {
       const trigger = sinon.spy(adapter, 'emit');
       const on = sinon.spy(watcher, 'on');
-      const revise = sinon.spy(watchRoot, 'revise');
+      const revise = sinon.spy(watchedNode, 'revise');
 
       expect(on).to.have.not.been.called;
       expect(trigger).to.have.not.been.called;
       expect(revise).to.have.not.been.called;
 
-      bindFileEvent(adapter, watcher, watchRoot, 'change');
+      bindFileEvent(adapter, watcher, watchedNode, 'change');
 
       expect(on).to.have.been.calledOnce;
       expect(trigger).to.have.been.calledOnce;
@@ -47,7 +47,7 @@ describe('WatcherAdapter', function() {
       expect(on).to.have.been.calledWith('change');
       expect(trigger).to.have.been.calledWith('change');
 
-      bindFileEvent(adapter, watcher, watchRoot, 'add');
+      bindFileEvent(adapter, watcher, watchedNode, 'add');
 
       expect(on).to.have.been.calledTwice;
       expect(trigger).to.have.been.calledTwice;
@@ -55,7 +55,7 @@ describe('WatcherAdapter', function() {
       expect(on).to.have.been.calledWith('add');
       expect(trigger).to.have.been.calledWith('change');
 
-      bindFileEvent(adapter, watcher, watchRoot, 'remove');
+      bindFileEvent(adapter, watcher, watchedNode, 'remove');
 
       expect(on).to.have.been.calledThrice;
       expect(trigger).to.have.been.calledThrice;
@@ -102,8 +102,20 @@ describe('WatcherAdapter', function() {
     const FIXTURE_PROJECT = __dirname + '/fixtures/project';
     let adapter;
 
-    const watchRoot = {
+    const watchedNodeBasic = {
       revise() {},
+      nodeInfo: {
+        nodeType: 'source',
+        sourceDirectory: FIXTURE_BASIC,
+      },
+    };
+
+    const watchedNodeProject = {
+      revise() {},
+      nodeInfo: {
+        nodeType: 'source',
+        sourceDirectory: FIXTURE_PROJECT,
+      },
     };
 
     afterEach(function() {
@@ -119,14 +131,14 @@ describe('WatcherAdapter', function() {
 
       expect(() => adapter.watch()).to.throw(
         TypeError,
-        `WatcherAdapter#watch's first argument must be an array of watchedPaths`
+        `WatcherAdapter#watch's first argument must be an array of WatchedDir nodes`
       );
 
       [null, undefined, NaN, {}, { length: 0 }, 'string', function() {}, Symbol('OMG')].forEach(
         arg => {
           expect(() => adapter.watch(arg)).to.throw(
             TypeError,
-            `WatcherAdapter#watch's first argument must be an array of watchedPaths`
+            `WatcherAdapter#watch's first argument must be an array of WatchedDir nodes`
           );
         }
       );
@@ -140,7 +152,8 @@ describe('WatcherAdapter', function() {
       expect(trigger).to.have.callCount(0);
 
       expect(adapter.watchers.length).to.eql(0);
-      let watching = adapter.watch([{ path: FIXTURE_BASIC, root: watchRoot }]);
+
+      let watching = adapter.watch([watchedNodeBasic]);
 
       expect(adapter.watchers.length).to.eql(1);
 
@@ -158,7 +171,7 @@ describe('WatcherAdapter', function() {
           trigger.resetHistory();
 
           // this time also watch the FIXTURE_PROJECT
-          let watching = adapter.watch([{ path: FIXTURE_PROJECT, root: watchRoot }]);
+          let watching = adapter.watch([watchedNodeProject]);
           expect(adapter.watchers.length).to.eql(2);
 
           return watching.then(val => {

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const expect = require('chai').expect;
+const Node = require('../lib/wrappers/node');
+const TransformNode = require('../lib/wrappers/transform-node');
+
+describe('transform-node', function() {
+  let transform;
+
+  beforeEach(() => {
+    transform = new TransformNode();
+    transform.nodeInfo = {
+      setup() {},
+      getCallbackObject() {
+        return this;
+      },
+      build() {},
+    };
+    transform.setup();
+    transform.inputNodeWrappers = [];
+  });
+
+  it('shouldBuild method should return false there are no input nodes and this is a rebuild', function() {
+    transform.nodeInfo.memoize = true;
+    transform._revision = 1;
+
+    expect(transform.shouldBuild()).to.be.false;
+  });
+
+  it('shouldBuild method should return false if none of the inputs changed', function() {
+    transform.nodeInfo.memoize = true;
+    transform.nodeInfo.persistentOutput = true;
+
+    let inputWrapperA = new Node();
+    let inputWrapperB = new Node();
+
+    transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
+
+    return transform.build().then(() => {
+      expect(transform.shouldBuild()).to.be.false;
+    });
+  });
+
+  it('shouldBuild method should return true if some of the inputs changed', function() {
+    transform.nodeInfo.memoize = true;
+    transform.nodeInfo.persistentOutput = true;
+
+    let inputWrapperA = new Node();
+    let inputWrapperB = new Node();
+
+    transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
+
+    return transform.build().then(() => {
+      inputWrapperA.revised();
+      expect(transform.shouldBuild()).to.be.true;
+    });
+  });
+});

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -22,31 +22,11 @@ describe('transform-node', function() {
   });
 
   afterEach(() => {
-    delete process.env['BROCCOLI_VOLATILE'];
+    delete process.env['BROCCOLI_ENABLED_VOLATILE'];
   });
 
-  it('memoizationEnabled method should return the correct value', function() {
-    process.env['BROCCOLI_VOLATILE'] = true;
-    expect(transform.memoizationEnabled(false)).to.be.true;
-
-    process.env['BROCCOLI_VOLATILE'] = false;
-    expect(transform.memoizationEnabled(true)).to.be.true;
-
-    process.env['BROCCOLI_VOLATILE'] = true;
-    expect(transform.memoizationEnabled()).to.be.true;
-
-    process.env['BROCCOLI_VOLATILE'] = false;
-    expect(transform.memoizationEnabled(false)).to.be.false;
-
-    delete process.env['BROCCOLI_VOLATILE'];
-    expect(transform.memoizationEnabled(false)).to.be.false;
-
-    delete process.env['BROCCOLI_VOLATILE'];
-    expect(transform.memoizationEnabled()).to.be.false;
-  });
-
-  it('shouldBuild method should return false there are no input nodes and this is a rebuild', function() {
-    process.env['BROCCOLI_VOLATILE'] = true;
+  it('shouldBuild should return false if there are no inputNodes and this is a rebuild', function() {
+    process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
 
     transform._revision = 0;
     expect(transform.shouldBuild()).to.be.true;
@@ -55,8 +35,8 @@ describe('transform-node', function() {
     expect(transform.shouldBuild()).to.be.false;
   });
 
-  it('shouldBuild method should return false if none of the inputs changed', function() {
-    process.env['BROCCOLI_VOLATILE'] = true;
+  it('shouldBuild method should return false if none of the inputNodes changed', function() {
+    process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
 
     let inputWrapperA = new Node();
     let inputWrapperB = new Node();
@@ -69,7 +49,7 @@ describe('transform-node', function() {
   });
 
   it('shouldBuild method should return true if some of the inputs changed', function() {
-    process.env['BROCCOLI_VOLATILE'] = true;
+    process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
 
     let inputWrapperA = new Node();
     let inputWrapperB = new Node();
@@ -82,7 +62,7 @@ describe('transform-node', function() {
     });
   });
 
-  it('if volatile is set to true then do not call revise', function() {
+  it('shouldBuild method should return true if none of the inputNodes changed and volatile is true', function() {
     transform.nodeInfo.volatile = true;
 
     let inputWrapperA = new Node();
@@ -90,27 +70,8 @@ describe('transform-node', function() {
 
     transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
 
+    expect(transform.shouldBuild()).to.be.true;
     inputWrapperA.revise();
-    expect(transform.revision).to.equal(0);
-
-    return transform.build().then(() => {
-      expect(transform.revision).to.equal(0);
-    });
-  });
-
-  it('if volatile is not set (or false) then revise is automatically called', function() {
-    transform.nodeInfo.volatile = false;
-
-    let inputWrapperA = new Node();
-    let inputWrapperB = new Node();
-
-    transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
-
-    inputWrapperA.revise();
-    expect(transform.revision).to.equal(0);
-
-    return transform.build().then(() => {
-      expect(transform.revision).to.equal(1);
-    });
+    expect(transform.shouldBuild()).to.be.true;
   });
 });

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -20,15 +20,19 @@ describe('transform-node', function() {
     transform.inputNodeWrappers = [];
   });
 
+  afterEach(() => {
+    delete process.env['BROCCOLI_VOLATILE'];
+  });
+
   it('shouldBuild method should return false there are no input nodes and this is a rebuild', function() {
-    transform.nodeInfo.memoize = true;
+    process.env['BROCCOLI_VOLATILE'] = true;
     transform._revision = 1;
 
     expect(transform.shouldBuild()).to.be.false;
   });
 
   it('shouldBuild method should return false if none of the inputs changed', function() {
-    transform.nodeInfo.memoize = true;
+    process.env['BROCCOLI_VOLATILE'] = true;
     transform.nodeInfo.persistentOutput = true;
 
     let inputWrapperA = new Node();
@@ -42,7 +46,8 @@ describe('transform-node', function() {
   });
 
   it('shouldBuild method should return true if some of the inputs changed', function() {
-    transform.nodeInfo.memoize = true;
+    process.env['BROCCOLI_VOLATILE'] = true;
+
     transform.nodeInfo.persistentOutput = true;
 
     let inputWrapperA = new Node();
@@ -51,7 +56,7 @@ describe('transform-node', function() {
     transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
 
     return transform.build().then(() => {
-      inputWrapperA.revised();
+      inputWrapperA.revise();
       expect(transform.shouldBuild()).to.be.true;
     });
   });

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -10,6 +10,7 @@ describe('transform-node', function() {
   beforeEach(() => {
     transform = new TransformNode();
     transform.nodeInfo = {
+      persistentOutput: true,
       setup() {},
       getCallbackObject() {
         return this;
@@ -24,16 +25,38 @@ describe('transform-node', function() {
     delete process.env['BROCCOLI_VOLATILE'];
   });
 
+  it('memoizationEnabled method should return the correct value', function() {
+    process.env['BROCCOLI_VOLATILE'] = true;
+    expect(transform.memoizationEnabled(false)).to.be.true;
+
+    process.env['BROCCOLI_VOLATILE'] = false;
+    expect(transform.memoizationEnabled(true)).to.be.true;
+
+    process.env['BROCCOLI_VOLATILE'] = true;
+    expect(transform.memoizationEnabled()).to.be.true;
+
+    process.env['BROCCOLI_VOLATILE'] = false;
+    expect(transform.memoizationEnabled(false)).to.be.false;
+
+    delete process.env['BROCCOLI_VOLATILE'];
+    expect(transform.memoizationEnabled(false)).to.be.false;
+
+    delete process.env['BROCCOLI_VOLATILE'];
+    expect(transform.memoizationEnabled()).to.be.false;
+  });
+
   it('shouldBuild method should return false there are no input nodes and this is a rebuild', function() {
     process.env['BROCCOLI_VOLATILE'] = true;
-    transform._revision = 1;
 
+    transform._revision = 0;
+    expect(transform.shouldBuild()).to.be.true;
+
+    transform._revision = 1;
     expect(transform.shouldBuild()).to.be.false;
   });
 
   it('shouldBuild method should return false if none of the inputs changed', function() {
     process.env['BROCCOLI_VOLATILE'] = true;
-    transform.nodeInfo.persistentOutput = true;
 
     let inputWrapperA = new Node();
     let inputWrapperB = new Node();
@@ -48,8 +71,6 @@ describe('transform-node', function() {
   it('shouldBuild method should return true if some of the inputs changed', function() {
     process.env['BROCCOLI_VOLATILE'] = true;
 
-    transform.nodeInfo.persistentOutput = true;
-
     let inputWrapperA = new Node();
     let inputWrapperB = new Node();
 
@@ -58,6 +79,38 @@ describe('transform-node', function() {
     return transform.build().then(() => {
       inputWrapperA.revise();
       expect(transform.shouldBuild()).to.be.true;
+    });
+  });
+
+  it('if volatile is set to true then do not call revise', function() {
+    transform.nodeInfo.volatile = true;
+
+    let inputWrapperA = new Node();
+    let inputWrapperB = new Node();
+
+    transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
+
+    inputWrapperA.revise();
+    expect(transform.revision).to.equal(0);
+
+    return transform.build().then(() => {
+      expect(transform.revision).to.equal(0);
+    });
+  });
+
+  it('if volatile is not set (or false) then revise is automatically called', function() {
+    transform.nodeInfo.volatile = false;
+
+    let inputWrapperA = new Node();
+    let inputWrapperB = new Node();
+
+    transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
+
+    inputWrapperA.revise();
+    expect(transform.revision).to.equal(0);
+
+    return transform.build().then(() => {
+      expect(transform.revision).to.equal(1);
     });
   });
 });

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -22,11 +22,11 @@ describe('transform-node', function() {
   });
 
   afterEach(() => {
-    delete process.env['BROCCOLI_ENABLED_VOLATILE'];
+    delete process.env['BROCCOLI_ENABLED_MEMOIZE'];
   });
 
   it('shouldBuild should return false if there are no inputNodes and this is a rebuild', function() {
-    process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
+    process.env['BROCCOLI_ENABLED_MEMOIZE'] = true;
 
     transform._revision = 0;
     expect(transform.shouldBuild()).to.be.true;
@@ -36,7 +36,7 @@ describe('transform-node', function() {
   });
 
   it('shouldBuild method should return false if none of the inputNodes changed', function() {
-    process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
+    process.env['BROCCOLI_ENABLED_MEMOIZE'] = true;
 
     let inputWrapperA = new Node();
     let inputWrapperB = new Node();
@@ -49,7 +49,7 @@ describe('transform-node', function() {
   });
 
   it('shouldBuild method should return true if some of the inputs changed', function() {
-    process.env['BROCCOLI_ENABLED_VOLATILE'] = true;
+    process.env['BROCCOLI_ENABLED_MEMOIZE'] = true;
 
     let inputWrapperA = new Node();
     let inputWrapperB = new Node();


### PR DESCRIPTION
## Background

Currently when a file change is detected broccoli will simply rebuild all of its nodes. Calling build can be expensive and results in nodes have to implement their own caching strategies (in best cases) or not caching (in worst cases). This PR "short circuits" the build chaining by enabling memoization (opt in via BROCCOLI_ENABLED_MEMOIZE=true) of nodes. This enables large amounts of the tree to no longer be rebuilt if broccoli detects that a nodes inputs have not changed (thus reducing rebuild times).

### How does this work

1. NodeWrappers (both source and transform) have a property called `_revision` that increments whenever their inputNodes have "changed"
2. This property is changed one of 2 ways. For source nodes the watcher_adapter calls `revise` on them whenever sane detects a change. For transform nodes, `revise` is automatically called whenever its build method is called.
3. During the build chain, we do not call the build method on a node if its inputNodes properties are the same as the last build attempt (a transform-node can "force" being built by passing `volatile=true` as an option).

### Related PRs
- broccolijs/broccoli-node-info#4
- broccolijs/broccoli-plugin#31