### PR TITLE
Pass watchedNodes to Watcher/WatcherAdapter

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -262,6 +262,12 @@ module.exports = class Builder extends EventEmitter {
     return nodeWrapper;
   }
 
+  get watchedSourceNodeWrappers() {
+    return this.nodeWrappers.filter(nw => {
+      return nw.nodeInfo.nodeType === 'source' && nw.nodeInfo.watched;
+    });
+  }
+
   checkInputPathsExist() {
     // We might consider checking this.unwatchedPaths as well.
     for (let i = 0; i < this.watchedPaths.length; i++) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -43,7 +43,11 @@ module.exports = function broccoliCLI(args) {
       const builder = getBuilder(options);
       const Watcher = getWatcher(options);
       const outputDir = options.outputPath;
-      const watcher = new Watcher(builder, buildWatcherOptions(options));
+      const watcher = new Watcher(
+        builder,
+        builder.watchedSourceNodeWrappers,
+        buildWatcherOptions(options)
+      );
 
       if (outputDir) {
         try {
@@ -112,7 +116,11 @@ module.exports = function broccoliCLI(args) {
       const builder = getBuilder(options);
       const Watcher = getWatcher(options);
       const outputTree = new TreeSync(builder.outputPath, outputDir);
-      const watcher = new Watcher(builder, buildWatcherOptions(options));
+      const watcher = new Watcher(
+        builder,
+        builder.watchedSourceNodeWrappers,
+        buildWatcherOptions(options)
+      );
 
       watcher.on('buildSuccess', () => {
         outputTree.sync();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,8 +66,7 @@ module.exports = function broccoliCLI(args) {
         watcher.on('buildSuccess', () => outputTree.sync());
       }
 
-      const server = broccoli.server.serve(watcher, options.host, parseInt(options.port, 10));
-      actionPromise = (server && server.closingPromise) || Promise.resolve();
+      actionPromise = broccoli.server.serve(watcher, options.host, parseInt(options.port, 10));
     });
 
   program

--- a/lib/dummy-watcher.js
+++ b/lib/dummy-watcher.js
@@ -7,16 +7,14 @@ module.exports = class Watcher extends EventEmitter {
     super();
     this.builder = builder;
     this.currentBuild = null;
-    this._lifetimeDeferred = null;
-  }
-
-  start() {
     let lifetime = (this._lifetimeDeferred = {});
     lifetime.promise = new Promise((resolve, reject) => {
       lifetime.resolve = resolve;
       lifetime.reject = reject;
     });
+  }
 
+  start() {
     this.currentBuild = this.builder.build();
     this.currentBuild
       .then(() => this.emit('buildSuccess'))

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -15,11 +15,13 @@ module.exports = {
 
   onBuildFailure(err) {
     console.log('Built with error:');
-    console.log(err.message);
-    if (!err.broccoliPayload || !err.broccoliPayload.location.file) {
+    if (err !== null && typeof err === 'object') {
+      console.log(err.message);
+      if (!err.broccoliPayload || !err.broccoliPayload.location.file) {
+        console.log('');
+        console.log(err.stack);
+      }
       console.log('');
-      console.log(err.stack);
     }
-    console.log('');
   },
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,67 +2,112 @@
 
 const promiseFinally = require('promise.prototype.finally');
 const http = require('http');
-
 const messages = require('./messages');
 const middleware = require('./middleware');
+const EventEmitter = require('events');
 
-exports.serve = function serve(watcher, host, port, _connect) {
-  if (watcher.constructor.name !== 'Watcher') throw new Error('Expected Watcher instance');
-  if (typeof host !== 'string') throw new Error('Expected host to bind to (e.g. "localhost")');
-  if (typeof port !== 'number' || port !== port)
-    throw new Error('Expected port to bind to (e.g. 4200)');
+class Server extends EventEmitter {
+  constructor(watcher, host, port, connect = require('connect')) {
+    super();
 
-  let connect = arguments.length > 3 ? _connect : require('connect');
+    this._watcher = watcher;
+    this._builder = watcher.builder;
+    this._host = host;
+    this._port = parseInt(port, 10);
+    this._connect = connect;
+    this._url = `http://${this._host}:${this._port}`;
+    this.app = this.http = null;
+    this._boundStop = this.stop.bind(this);
+    this._started = false;
 
-  const server = {
-    onBuildSuccessful: () => messages.onBuildSuccess(watcher.builder),
-    cleanupAndExit,
-  };
-
-  console.log(`Serving on http://${host}:${port}\n`);
-
-  server.watcher = watcher;
-  server.builder = server.watcher.builder;
-
-  server.app = connect().use(middleware(server.watcher));
-
-  server.http = http.createServer(server.app);
-  server.http.listen(parseInt(port, 10), host);
-  server.http.on('error', error => {
-    if (error.code !== 'EADDRINUSE') {
-      throw error;
+    if (watcher.constructor.name !== 'Watcher') {
+      throw new Error('Expected Watcher instance');
     }
 
-    let message = `Oh snap 😫. It appears a server is already running on http://${host}:${port}\n`;
-    message += `Are you perhaps already running serve in another terminal window?\n`;
+    if (typeof host !== 'string') {
+      throw new Error('Expected host to bind to (e.g. "localhost")');
+    }
 
-    console.error(message);
-    process.exit(1);
-  });
-
-  // We register these so the 'exit' handler removing temp dirs is called
-  function cleanupAndExit() {
-    return server.watcher.quit();
+    if (typeof port !== 'number' || port !== port) {
+      throw new Error('Expected port to bind to (e.g. 4200)');
+    }
   }
 
-  process.on('SIGINT', cleanupAndExit);
-  process.on('SIGTERM', cleanupAndExit);
-
-  server.watcher.on('buildSuccess', () => server.onBuildSuccessful());
-  server.watcher.on('buildFailure', messages.onBuildFailure);
-
-  server.closingPromise = promiseFinally(
-    server.watcher.start().catch(err => console.log((err && err.stack) || err)),
-    () => {
-      server.builder.cleanup();
-      server.http.close();
-      process.exit(0);
+  start() {
+    if (this._started) {
+      throw new Error('Watcher.prototype.start() must not be called more than once');
     }
-  ).catch(err => {
-    console.log('Cleanup error:');
-    console.log((err && err.stack) || err);
-    process.exit(1);
-  });
 
-  return server;
+    const promise = new Promise((resolve, reject) => {
+      this.app = this._connect().use(middleware(this._watcher));
+
+      this.http = http.createServer(this.app);
+      this.http.listen(this._port, this._host);
+
+      this.http.on('listening', () => {
+        console.log(`Serving on ${this._url}\n`);
+        resolve(this._watcher.start());
+      });
+
+      this.http.on('error', error => {
+        if (error.code !== 'EADDRINUSE') {
+          throw error;
+        }
+
+        let message = `Oh snap 😫. It appears a server is already running on ${this._url}\n`;
+        message += `Are you perhaps already running serve in another terminal window?\n`;
+        reject(new Error(message));
+      });
+
+      process.addListener('SIGINT', this._boundStop);
+      process.addListener('SIGTERM', this._boundStop);
+
+      this._watcher.on('buildSuccess', () => {
+        this.emit('buildSuccess');
+        messages.onBuildSuccess(this._builder);
+      });
+
+      this._watcher.on('buildFailure', () => {
+        this.emit('buildFailure');
+        messages.onBuildFailure();
+      });
+    });
+
+    return promiseFinally(promise, () => this.stop());
+  }
+
+  _detachListeners() {
+    process.removeListener('SIGINT', this._boundStop);
+    process.removeListener('SIGTERM', this._boundStop);
+  }
+
+  stop() {
+    this._detachListeners();
+    if (this.http) {
+      this.http.close();
+    }
+
+    return this._watcher.quit().then(() => this._builder.cleanup());
+  }
+}
+
+exports.serve = function serve(
+  watcher,
+  host,
+  port,
+  _connect = require('connect'),
+  _process = process
+) {
+  const server = new Server(watcher, host, port, _connect);
+
+  return server
+    .start()
+    .then(() => _process.exit(0))
+    .catch(err => {
+      console.log('Broccoli Cleanup error:');
+      console.log((err && err.stack) || err);
+      _process.exit(1);
+    });
 };
+
+exports.Server = Server;

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -10,12 +10,15 @@ const logger = require('heimdalljs-logger')('broccoli:watcher');
 // principle.
 
 module.exports = class Watcher extends EventEmitter {
-  constructor(builder, options) {
+  constructor(builder, watchedNodes, options) {
     super();
     this.options = options || {};
-    if (this.options.debounce == null) this.options.debounce = 100;
+    if (this.options.debounce == null) {
+      this.options.debounce = 100;
+    }
     this.builder = builder;
-    this.watcherAdapter = new WatcherAdapter(this.options.saneOptions);
+    this.watcherAdapter =
+      this.options.watcherAdapter || new WatcherAdapter(watchedNodes, this.options.saneOptions);
     this.currentBuild = null;
     this._rebuildScheduled = false;
     this._ready = false;
@@ -24,8 +27,9 @@ module.exports = class Watcher extends EventEmitter {
   }
 
   start() {
-    if (this._lifetimeDeferred != null)
+    if (this._lifetimeDeferred != null) {
       throw new Error('Watcher.prototype.start() must not be called more than once');
+    }
     let lifetime = (this._lifetimeDeferred = {});
     lifetime.promise = new Promise((resolve, reject) => {
       lifetime.resolve = resolve;
@@ -36,11 +40,7 @@ module.exports = class Watcher extends EventEmitter {
     this.watcherAdapter.on('error', this._error.bind(this));
     this.currentBuild = Promise.resolve()
       .then(() => {
-        let watchedSourceNodes = this.builder.nodeWrappers.filter(nw => {
-          return nw.nodeInfo.nodeType === 'source' && nw.nodeInfo.watched;
-        });
-
-        return this.watcherAdapter.watch(watchedSourceNodes);
+        return this.watcherAdapter.watch();
       })
       .then(() => {
         logger.debug('ready');
@@ -108,7 +108,9 @@ module.exports = class Watcher extends EventEmitter {
 
   _error(err) {
     logger.debug('error', err);
-    if (this._quitting) return;
+    if (this._quitting) {
+      return;
+    }
     this._quit()
       .catch(() => {})
       .then(() => this._lifetimeDeferred.reject(err));

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -10,28 +10,30 @@ const logger = require('heimdalljs-logger')('broccoli:watcher');
 // principle.
 
 module.exports = class Watcher extends EventEmitter {
-  constructor(builder, watchedNodes, options) {
+  constructor(builder, watchedNodes = [], options = {}) {
     super();
-    this.options = options || {};
+    this.options = options;
     if (this.options.debounce == null) {
       this.options.debounce = 100;
     }
     this.builder = builder;
     this.watcherAdapter =
-      this.options.watcherAdapter || new WatcherAdapter(watchedNodes, this.options.saneOptions);
+      this.options.watcherAdapter ||
+      new WatcherAdapter(watchedNodes || [], this.options.saneOptions);
+
     this.currentBuild = null;
     this._rebuildScheduled = false;
     this._ready = false;
     this._quittingPromise = null;
-    this._lifetimeDeferred = null;
+    this._lifetime = null;
   }
 
   start() {
-    if (this._lifetimeDeferred != null) {
+    if (this._lifetime != null) {
       throw new Error('Watcher.prototype.start() must not be called more than once');
     }
 
-    let lifetime = (this._lifetimeDeferred = {});
+    let lifetime = (this._lifetime = {});
     lifetime.promise = new Promise((resolve, reject) => {
       lifetime.resolve = resolve;
       lifetime.reject = reject;
@@ -51,7 +53,7 @@ module.exports = class Watcher extends EventEmitter {
       .catch(err => this._error(err))
       .then(() => this.currentBuild);
 
-    return this._lifetimeDeferred.promise;
+    return this._lifetime.promise;
   }
 
   _change(event, filePath, root) {
@@ -123,7 +125,7 @@ module.exports = class Watcher extends EventEmitter {
     this.emit('error', err);
     return this._quit()
       .catch(() => {})
-      .then(() => this._lifetimeDeferred.reject(err));
+      .then(() => this._lifetime.reject(err));
   }
 
   quit() {
@@ -132,10 +134,14 @@ module.exports = class Watcher extends EventEmitter {
       return this._quittingPromise;
     }
 
-    return this._quit().then(
-      () => this._lifetimeDeferred.resolve(),
-      err => this._lifetimeDeferred.reject(err)
-    );
+    let quitting = this._quit();
+
+    if (this._lifetime) {
+      this._lifetime.resolve(quitting);
+      return this._lifetime.promise;
+    } else {
+      return quitting;
+    }
   }
 
   _quit() {

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('events').EventEmitter;
 const sane = require('sane');
 const logger = require('heimdalljs-logger')('broccoli:watcherAdapter');
+const SourceNode = require('./wrappers/source-node');
 
 function defaultFilterFunction(name) {
   return /^[^.]/.test(name);
@@ -18,20 +19,29 @@ function bindFileEvent(adapter, watcher, node, event) {
 }
 
 module.exports = class WatcherAdapter extends EventEmitter {
-  constructor(options) {
+  constructor(watchedNodes, options) {
     super();
+    if (!Array.isArray(watchedNodes)) {
+      throw new TypeError(
+        `WatcherAdapter's first argument must be an array of SourceNodeWrapper nodes`
+      );
+    }
+    for (const node of watchedNodes) {
+      if (!(node instanceof SourceNode)) {
+        throw new Error(`${node} is not a SourceNode`);
+      }
+      if (node.nodeInfo.watched !== true) {
+        throw new Error(`${node.nodeInfo.sourceDirectory} it not watched`);
+      }
+    }
+    this.watchedNodes = watchedNodes;
     this.options = options || {};
     this.options.filter = this.options.filter || defaultFilterFunction;
     this.watchers = [];
   }
 
-  watch(watchedSourceNodes) {
-    if (!Array.isArray(watchedSourceNodes)) {
-      throw new TypeError(
-        `WatcherAdapter#watch's first argument must be an array of WatchedDir nodes`
-      );
-    }
-    let watchers = watchedSourceNodes.map(node => {
+  watch() {
+    let watchers = this.watchedNodes.map(node => {
       const watchedPath = node.nodeInfo.sourceDirectory;
       const watcher = new sane(watchedPath, this.options);
       this.watchers.push(watcher);

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -19,7 +19,7 @@ function bindFileEvent(adapter, watcher, node, event) {
 }
 
 module.exports = class WatcherAdapter extends EventEmitter {
-  constructor(watchedNodes, options) {
+  constructor(watchedNodes = [], options) {
     super();
     if (!Array.isArray(watchedNodes)) {
       throw new TypeError(
@@ -31,7 +31,7 @@ module.exports = class WatcherAdapter extends EventEmitter {
         throw new Error(`${node} is not a SourceNode`);
       }
       if (node.nodeInfo.watched !== true) {
-        throw new Error(`${node.nodeInfo.sourceDirectory} it not watched`);
+        throw new Error(`'${node.nodeInfo.sourceDirectory}' is not watched`);
       }
     }
     this.watchedNodes = watchedNodes;

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -387,6 +387,17 @@ describe('Builder', function() {
         /test\/fixtures\/basic\/foo\.txt: Not a directory/
       );
     });
+
+    it('returns only watched SourceNodeWrappers from watchedSourceNodeWrappers', function() {
+      const source1 = new broccoliSource.WatchedDir('test/fixtures/basic/');
+      const source2 = new broccoliSource.UnwatchedDir('test/fixtures/empty/');
+      builder = new Builder(new plugins.Merge([source1, source2]));
+
+      const watchedSourceNodeWrappers = builder.watchedSourceNodeWrappers;
+
+      expect(watchedSourceNodeWrappers).length.to.be(1);
+      expect(watchedSourceNodeWrappers[0].node).to.equal(source1)
+    })
   });
 
   describe('error handling in constructor', function() {

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -396,8 +396,8 @@ describe('Builder', function() {
       const watchedSourceNodeWrappers = builder.watchedSourceNodeWrappers;
 
       expect(watchedSourceNodeWrappers).length.to.be(1);
-      expect(watchedSourceNodeWrappers[0].node).to.equal(source1)
-    })
+      expect(watchedSourceNodeWrappers[0].node).to.equal(source1);
+    });
   });
 
   describe('error handling in constructor', function() {

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -330,7 +330,6 @@ describe('cli', function() {
       sinon
         .stub(WatchDetector.prototype, 'findBestWatcherOption')
         .value(() => ({ watcher: 'polling' }));
-      sinon.stub(broccoli, 'server').value({ serve() {} });
       const spy = createWatcherSpy();
       // --watch is passed so Watcher spy can be used
       return cli(['node', 'broccoli', 'serve']).then(() =>
@@ -541,7 +540,6 @@ describe('cli', function() {
   context('with param --watcher', function() {
     it('creates watcher with sane options for watchman', function() {
       sinon.stub(childProcess, 'execSync').returns(JSON.stringify({ version: '4.0.0' }));
-      sinon.stub(broccoli, 'server').value({ serve() {} });
       const spy = createWatcherSpy();
       return cli(['node', 'broccoli', 'serve', '--watcher', 'watchman']).then(() =>
         chai.expect(spy).to.have.been.calledWith(
@@ -560,7 +558,6 @@ describe('cli', function() {
     });
 
     it('creates watcher with sane options for node', function() {
-      sinon.stub(broccoli, 'server').value({ serve() {} });
       const spy = createWatcherSpy();
       return cli(['node', 'broccoli', 'serve', '--watcher', 'node']).then(() =>
         chai.expect(spy).to.have.been.calledWith(
@@ -579,7 +576,6 @@ describe('cli', function() {
     });
 
     it('creates watcher with sane options for polling', function() {
-      sinon.stub(broccoli, 'server').value({ serve() {} });
       const spy = createWatcherSpy();
       return cli(['node', 'broccoli', 'serve', '--watcher', 'polling']).then(() =>
         chai.expect(spy).to.have.been.calledWith(
@@ -599,6 +595,7 @@ describe('cli', function() {
   });
 });
 
+// TODO: remove these mocks and spys
 function createWatcherSpy() {
   const spy = sinon.spy();
   sinon.stub(broccoli, 'Watcher').value(
@@ -609,6 +606,9 @@ function createWatcherSpy() {
       }
 
       start() {
+        return Promise.resolve();
+      }
+      quit() {
         return Promise.resolve();
       }
     }

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -48,6 +48,7 @@ describe('cli', function() {
       return cli(['node', 'broccoli', 'build', 'dist', '--watch']).then(() =>
         chai.expect(spy).to.have.been.calledWith(
           sinon.match.instanceOf(Builder),
+          sinon.match.array,
           sinon.match.has(
             'saneOptions',
             sinon.match({
@@ -140,6 +141,7 @@ describe('cli', function() {
           () =>
             chai.expect(spy).to.have.been.calledWith(
               sinon.match.instanceOf(Builder),
+              sinon.match.array,
               sinon.match.has(
                 'saneOptions',
                 sinon.match({
@@ -159,6 +161,7 @@ describe('cli', function() {
           () =>
             chai.expect(spy).to.have.been.calledWith(
               sinon.match.instanceOf(Builder),
+              sinon.match.array,
               sinon.match.has(
                 'saneOptions',
                 sinon.match({
@@ -176,6 +179,7 @@ describe('cli', function() {
         return cli(['node', 'broccoli', 'build', 'dist', '--watch', '--watcher', 'node']).then(() =>
           chai.expect(spy).to.have.been.calledWith(
             sinon.match.instanceOf(Builder),
+            sinon.match.array,
             sinon.match.has(
               'saneOptions',
               sinon.match({
@@ -332,6 +336,7 @@ describe('cli', function() {
       return cli(['node', 'broccoli', 'serve']).then(() =>
         chai.expect(spy).to.have.been.calledWith(
           sinon.match.instanceOf(Builder),
+          sinon.match.array,
           sinon.match.has(
             'saneOptions',
             sinon.match({
@@ -541,6 +546,7 @@ describe('cli', function() {
       return cli(['node', 'broccoli', 'serve', '--watcher', 'watchman']).then(() =>
         chai.expect(spy).to.have.been.calledWith(
           sinon.match.instanceOf(Builder),
+          sinon.match.array,
           sinon.match.has(
             'saneOptions',
             sinon.match({
@@ -559,6 +565,7 @@ describe('cli', function() {
       return cli(['node', 'broccoli', 'serve', '--watcher', 'node']).then(() =>
         chai.expect(spy).to.have.been.calledWith(
           sinon.match.instanceOf(Builder),
+          sinon.match.array,
           sinon.match.has(
             'saneOptions',
             sinon.match({
@@ -577,6 +584,7 @@ describe('cli', function() {
       return cli(['node', 'broccoli', 'serve', '--watcher', 'polling']).then(() =>
         chai.expect(spy).to.have.been.calledWith(
           sinon.match.instanceOf(Builder),
+          sinon.match.array,
           sinon.match.has(
             'saneOptions',
             sinon.match({
@@ -595,9 +603,9 @@ function createWatcherSpy() {
   const spy = sinon.spy();
   sinon.stub(broccoli, 'Watcher').value(
     class Watcher extends DummyWatcher {
-      constructor(builder, options) {
-        super(builder, options);
-        spy.call(null, builder, options);
+      constructor(builder, watchedSourceNodes, options) {
+        super(builder, watchedSourceNodes, options);
+        spy.call(null, builder, watchedSourceNodes, options);
       }
 
       start() {

--- a/test/watch_adapter_test.js
+++ b/test/watch_adapter_test.js
@@ -40,7 +40,6 @@ describe('WatcherAdapter', function() {
     watched: true,
   };
 
-
   describe('bindFileEvent', function() {
     const adapter = {
       emit() {},
@@ -137,10 +136,7 @@ describe('WatcherAdapter', function() {
     });
 
     it('throws if you try to watch a non node', function() {
-      expect(() => new WatcherAdapter([{}])).to.throw(
-        Error,
-        `[object Object] is not a SourceNode`
-      );
+      expect(() => new WatcherAdapter([{}])).to.throw(Error, `[object Object] is not a SourceNode`);
     });
 
     it('throws if you try to watch a non-source node', function() {

--- a/test/watcher_adapter_test.js
+++ b/test/watcher_adapter_test.js
@@ -120,19 +120,12 @@ describe('WatcherAdapter', function() {
     });
 
     it('throws if you try to watch a non array', function() {
-      expect(() => new WatcherAdapter()).to.throw(
-        TypeError,
-        `WatcherAdapter's first argument must be an array of SourceNodeWrapper nodes`
-      );
-
-      [null, undefined, NaN, {}, { length: 0 }, 'string', function() {}, Symbol('OMG')].forEach(
-        arg => {
-          expect(() => new WatcherAdapter(arg)).to.throw(
-            TypeError,
-            `WatcherAdapter's first argument must be an array of SourceNodeWrapper nodes`
-          );
-        }
-      );
+      [NaN, {}, { length: 0 }, 'string', function() {}, Symbol('OMG')].forEach(arg => {
+        expect(() => new WatcherAdapter(arg)).to.throw(
+          TypeError,
+          `WatcherAdapter's first argument must be an array of SourceNodeWrapper nodes`
+        );
+      });
     });
 
     it('throws if you try to watch a non node', function() {
@@ -149,7 +142,7 @@ describe('WatcherAdapter', function() {
     it('throws if you try to watch a non-watchable node', function() {
       expect(() => new WatcherAdapter([unwatchedNodeBasic])).to.throw(
         Error,
-        `/Users/goli/Projects/broccoli/test/fixtures/basic it not watched`
+        /[/\\]broccoli[/\\]test[/\\]fixtures[/\\]basic' is not watched/
       );
     });
   });

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -10,7 +10,14 @@ chai.use(sinonChai);
 const sinon = require('sinon').createSandbox();
 
 describe('Watcher', function() {
+  let watcher;
+
   afterEach(function() {
+    if (watcher) {
+      watcher.quit();
+      watcher = null;
+    }
+
     sinon.restore();
   });
 
@@ -39,7 +46,7 @@ describe('Watcher', function() {
       const builderBuild = sinon.spy(builder, 'build');
 
       const watchedNodes = [watchedNodeBasic];
-      const watcher = new Watcher(builder, watchedNodes);
+      watcher = new Watcher(builder, watchedNodes);
       const trigger = sinon.stub(watcher, 'emit');
       const adapterOn = sinon.spy(watcher.watcherAdapter, 'on');
       const adapterWatch = sinon.spy(watcher.watcherAdapter, 'watch');
@@ -59,10 +66,9 @@ describe('Watcher', function() {
     });
 
     it('throws error if called twice', function() {
-      const watcher = new Watcher(builder, [watchedNodeBasic], { watcherAdapter: adapter });
-
-      watcher._lifetimeDeferred = true;
-      expect(watcher.start.bind(watcher)).to.throw(
+      const watcher = new Watcher(builder, [], { watcherAdapter: adapter });
+      watcher.start();
+      expect(() => watcher.start()).to.throw(
         'Watcher.prototype.start() must not be called more than once'
       );
     });
@@ -93,7 +99,6 @@ describe('Watcher', function() {
   describe('change', function() {
     it('on change, rebuild is invoked', function() {
       const builderBuild = sinon.spy(builder, 'build');
-
       const watcher = new Watcher(builder, [watchedNodeBasic], { watcherAdapter: adapter });
 
       let changeHandler = sinon.spy();
@@ -120,7 +125,6 @@ describe('Watcher', function() {
 
     it('does nothing if not ready', function() {
       const builderBuild = sinon.spy(builder, 'build');
-
       const watcher = new Watcher(builder, [watchedNodeBasic], { watcherAdapter: adapter });
 
       let changeHandler = sinon.spy();
@@ -133,7 +137,6 @@ describe('Watcher', function() {
 
     it('does nothing if rebuilding', function() {
       const builderBuild = sinon.spy(builder, 'build');
-
       const watcher = new Watcher(builder, [watchedNodeBasic], { watcherAdapter: adapter });
 
       let changeHandler = sinon.spy();


### PR DESCRIPTION
The intention of this PR is to make the `watchedNodes` an argument to the constructor of the watcher, as they're a required dependency and watcher can't work without them.
Additionally, NOT reaching into the builder to get them will help with the ember CLI integration of the watcher.