### PR TITLE
Require watchedNodes arguments to Watcher/WatcherAdapter

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -10,7 +10,7 @@ const logger = require('heimdalljs-logger')('broccoli:watcher');
 // principle.
 
 module.exports = class Watcher extends EventEmitter {
-  constructor(builder, watchedNodes = [], options = {}) {
+  constructor(builder, watchedNodes, options = {}) {
     super();
     this.options = options;
     if (this.options.debounce == null) {
@@ -19,7 +19,7 @@ module.exports = class Watcher extends EventEmitter {
     this.builder = builder;
     this.watcherAdapter =
       this.options.watcherAdapter ||
-      new WatcherAdapter(watchedNodes || [], this.options.saneOptions);
+      new WatcherAdapter(watchedNodes, this.options.saneOptions);
 
     this.currentBuild = null;
     this._rebuildScheduled = false;

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -18,8 +18,7 @@ module.exports = class Watcher extends EventEmitter {
     }
     this.builder = builder;
     this.watcherAdapter =
-      this.options.watcherAdapter ||
-      new WatcherAdapter(watchedNodes, this.options.saneOptions);
+      this.options.watcherAdapter || new WatcherAdapter(watchedNodes, this.options.saneOptions);
 
     this.currentBuild = null;
     this._rebuildScheduled = false;

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -19,7 +19,7 @@ function bindFileEvent(adapter, watcher, node, event) {
 }
 
 module.exports = class WatcherAdapter extends EventEmitter {
-  constructor(watchedNodes = [], options) {
+  constructor(watchedNodes, options) {
     super();
     if (!Array.isArray(watchedNodes)) {
       throw new TypeError(

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -52,8 +52,8 @@ describe('server', function() {
 
   it('errors if port already in use', function() {
     const builder = new Builder(new broccoliSource.WatchedDir('test/fixtures/basic'));
-    const serverOne = new Server.Server(new Watcher(builder), '127.0.0.1', PORT, undefined);
-    const serverTwo = new Server.Server(new Watcher(builder), '127.0.0.1', PORT, undefined);
+    const serverOne = new Server.Server(new Watcher(builder, []), '127.0.0.1', PORT, undefined);
+    const serverTwo = new Server.Server(new Watcher(builder, []), '127.0.0.1', PORT, undefined);
 
     serverOne.start();
 
@@ -73,7 +73,7 @@ describe('server', function() {
 
   it('buildSuccess is handled', function() {
     const builder = new Builder(new broccoliSource.WatchedDir('test/fixtures/basic'));
-    const watcher = new Watcher(builder);
+    const watcher = new Watcher(builder, []);
     server = new Server.Server(watcher, '127.0.0.1', PORT);
 
     const start = server.start();
@@ -92,7 +92,7 @@ describe('server', function() {
 
   it('supports being provided a custom connect middleware root', function() {
     const builder = new Builder(new broccoliSource.WatchedDir('test/fixtures/basic'));
-    const watcher = new Watcher(builder);
+    const watcher = new Watcher(builder, []);
     let altConnectWasUsed = false;
 
     function altConnect() {
@@ -117,7 +117,7 @@ describe('server', function() {
       new Date('2018-07-27T17:23:02.000Z')
     );
     const builder = new Builder(new broccoliSource.WatchedDir('test/fixtures/public'));
-    const watcher = new Watcher(builder);
+    const watcher = new Watcher(builder, []);
     server = new Server.Server(watcher, '127.0.0.1', PORT);
     server.start();
 


### PR DESCRIPTION
As the title says, per @rwjblue suggestion