### PR TITLE
[feature] stop current build, when rebuild is triggered

### DIFF
--- a/lib/watcher.ts
+++ b/lib/watcher.ts
@@ -22,7 +22,7 @@ class Watcher extends EventEmitter {
   _ready: boolean;
   _quittingPromise: Promise<void> | null;
   _lifetime: {
-    promise?: Promise<void>,
+    promise?: Promise<void>;
     resolve?: (value: any) => void;
     reject?: (error: any) => void;
   } | null;
@@ -109,7 +109,7 @@ class Watcher extends EventEmitter {
   }
 
   async ready() {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       this.on('ready', () => {
         resolve();
       });

--- a/lib/watcher.ts
+++ b/lib/watcher.ts
@@ -109,11 +109,7 @@ class Watcher extends EventEmitter {
   }
 
   async ready() {
-    return new Promise(resolve => {
-      this.on('ready', () => {
-        resolve();
-      });
-    });
+    await new Promise(resolve => this.on('ready', resolve));
   }
 
   async _change(event: 'change', filePath: string, root: string) {

--- a/lib/watcher.ts
+++ b/lib/watcher.ts
@@ -109,7 +109,7 @@ class Watcher extends EventEmitter {
   }
 
   async ready() {
-    await new Promise(resolve => this.on('ready', resolve));
+    await new Promise(resolve => this.once('ready', resolve));
   }
 
   async _change(event: 'change', filePath: string, root: string) {

--- a/lib/watcher.ts
+++ b/lib/watcher.ts
@@ -95,6 +95,7 @@ class Watcher extends EventEmitter {
         try {
           await this.watcherAdapter.watch();
           logger.debug('ready');
+          this.emit('ready');
           this._ready = true;
         } catch (e) {
           this._error(e);
@@ -105,6 +106,14 @@ class Watcher extends EventEmitter {
     );
 
     return this._lifetime.promise;
+  }
+
+  async ready() {
+    return new Promise((resolve) => {
+      this.on('ready', () => {
+        resolve();
+      });
+    });
   }
 
   async _change(event: 'change', filePath: string, root: string) {

--- a/lib/watcher.ts
+++ b/lib/watcher.ts
@@ -123,6 +123,9 @@ class Watcher extends EventEmitter {
     this._rebuildScheduled = true;
 
     try {
+      // cancel the current builder and wait for it to finish the current plugin
+      await this.builder.cancel();
+
       // Wait for current build, and ignore build failure
       await this.currentBuild;
     } catch (e) {

--- a/test/multidep.json
+++ b/test/multidep.json
@@ -1,6 +1,7 @@
 {
   "path": "test/multidep",
   "versions": {
+    "broccoli-merge-trees": ["4.1.0"],
     "broccoli-plugin": ["1.0.0", "1.1.0", "1.2.3", "1.3.0", "2.0.0", "2.1.0", "3.0.0"],
     "broccoli-source": ["1.1.0", "2.0.0", "2.1.1", "2.1.2", "3.0.0"]
   }

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -174,7 +174,7 @@ describe('Watcher', function() {
         }
 
         build() {
-          pluginsCalled['plugin1'] = pluginsCalled['plugin1'] ? pluginsCalled['plugin1'] + 1 : 1;
+    events.push('plugin1 build');
 
           return waitForPlugin1.promise;
         }

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -163,7 +163,7 @@ describe('Watcher', function() {
     });
 
     it('on change, rebuild is invoked and cancel is invoked from the build', function() {
-      const pluginsCalled = {};
+      const events = [];
 
       const waitForPlugin1 = defer();
       const waitForPlugin2 = defer();

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -170,7 +170,7 @@ describe('Watcher', function() {
 
       class Plugin1 extends Plugin {
         build() {
-    events.push('plugin1 build');
+          events.push('plugin1');
 
           return waitForPlugin1.promise;
         }
@@ -178,7 +178,7 @@ describe('Watcher', function() {
 
       class Plugin2 extends Plugin {
         build() {
-    events.push('plugin2 build');
+          events.push('plugin2');
 
           return waitForPlugin2.promise;
         }
@@ -202,18 +202,12 @@ describe('Watcher', function() {
           return changedBuild;
         })
         .then(() => {
-          expect(events).to.deep.equal([
-            'plugin 1',
-          ]);
+          expect(events).to.deep.equal(['plugin1']);
 
           return watcher.currentBuild;
         })
         .then(() => {
-          expect(events).to.deep.equal([
-            'plugin1',
-            'plugin1',
-            'plugin2',
-          ]);
+          expect(events).to.deep.equal(['plugin1', 'plugin1', 'plugin2']);
         });
     }).timeout(600000);
 

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -178,7 +178,7 @@ describe('Watcher', function() {
 
       class Plugin2 extends Plugin {
         build() {
-          pluginsCalled['plugin2'] = pluginsCalled['plugin2'] ? pluginsCalled['plugin2'] + 1 : 1;
+    events.push('plugin2 build');
 
           return waitForPlugin2.promise;
         }

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -185,7 +185,7 @@ describe('Watcher', function() {
       }
 
       const plugin1 = new Plugin1([]);
-      const plugin2 = new Plugin2();
+      const plugin2 = new Plugin2([]);
       const builder = new Builder(Merge([plugin1, plugin2]));
       const watcher = new Watcher(builder, [watchedNodeBasic], { watcherAdapter: adapter });
 

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -48,7 +48,7 @@ describe('Watcher', function() {
     async build(_, buildAnnotation) {
       return buildAnnotation;
     },
-    async cancel() { },
+    async cancel() {},
   };
 
   const adapter = {

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -184,7 +184,7 @@ describe('Watcher', function() {
         }
       }
 
-      const plugin1 = new Plugin1();
+      const plugin1 = new Plugin1([]);
       const plugin2 = new Plugin2();
       const builder = new Builder(Merge([plugin1, plugin2]));
       const watcher = new Watcher(builder, [watchedNodeBasic], { watcherAdapter: adapter });

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -217,8 +217,11 @@ describe('Watcher', function() {
           return watcher.currentBuild;
         })
         .then(() => {
-          expect(pluginsCalled['plugin1']).to.eq(2);
-          expect(pluginsCalled['plugin2']).to.eq(1);
+          expect(events).to.deep.equal([
+            'plugin1',
+            'plugin1',
+            'plugin2',
+          ]);
         });
     }).timeout(600000);
 

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -177,10 +177,6 @@ describe('Watcher', function() {
       }
 
       class Plugin2 extends Plugin {
-        constructor(inputNodes, options) {
-          super(inputNodes || [], options);
-        }
-
         build() {
           pluginsCalled['plugin2'] = pluginsCalled['plugin2'] ? pluginsCalled['plugin2'] + 1 : 1;
 

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -21,8 +21,8 @@ function defer() {
   return deferred;
 }
 
-function sleep() {
-  return new Promise(resolve => setTimeout(resolve, 10));
+function sleep(timeout = 10) {
+  return new Promise(resolve => setTimeout(resolve, timeout));
 }
 
 const expect = chai.expect;

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -169,10 +169,6 @@ describe('Watcher', function() {
       const waitForPlugin2 = defer();
 
       class Plugin1 extends Plugin {
-        constructor(inputNodes, options) {
-          super(inputNodes || [], options);
-        }
-
         build() {
     events.push('plugin1 build');
 

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -48,9 +48,7 @@ describe('Watcher', function() {
     async build(_, buildAnnotation) {
       return buildAnnotation;
     },
-    async cancel() {
-      return Promise.resolve();
-    },
+    async cancel() { },
   };
 
   const adapter = {

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -227,9 +227,7 @@ describe('Watcher', function() {
 
       watcher.start();
 
-      watcher.ready().then(() => {
-        expect(true).to.be.true;
-      });
+      await watcher.ready();
     });
 
     it('does nothing if not ready', function() {

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -210,8 +210,9 @@ describe('Watcher', function() {
           return changedBuild;
         })
         .then(() => {
-          expect(pluginsCalled['plugin1']).to.eq(1);
-          expect(pluginsCalled['plugin2']).to.eq(undefined);
+          expect(events).to.deep.equal([
+            'plugin 1',
+          ]);
 
           return watcher.currentBuild;
         })


### PR DESCRIPTION
fixes #407 

_taken from @rwjblue_

```
Steps to repro:

Have a large build pipeline that takes a few seconds
change a file (kicks off a rebuild)
change another file during that rebuild
Expected result:

Broccoli should stop calling any node's .build method immediately after step 3 (essentially short circuiting the build) and start over
Actual result:

The build from step 2 completes then the build queued up in step 3 starts, therefore taking 2x the total time (time to complete two rebuilds vs time to do one full rebuild and whatever partial amount was previously completed when step 3 happens)
```