### PR TITLE
[FEATURE] Input node change tracking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2018,
   },
   plugins: ['node', 'prettier'],
   extends: ['eslint:recommended', 'plugin:node/recommended'],

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -22,11 +22,6 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
   }
 
   shouldBuild() {
-    // The plugin has told us they should always build
-    if (this.nodeInfo.volatile === true) {
-      return true;
-    }
-
     let nodesThatChanged = [];
     this.inputNodeWrappers.forEach(wrapper => {
       let wrapper_revision_meta = this.inputRevisions.get(wrapper);
@@ -38,6 +33,11 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
         this.inputRevisions.set(wrapper, { revision: wrapper.revision, changed: false });
       }
     });
+
+    // The plugin has told us they should always build
+    if (this.nodeInfo.volatile === true) {
+      return true;
+    }
 
     // Memoization is currently optin via BROCCOLI_ENABLED_MEMOIZE = true
     if (process.env.BROCCOLI_ENABLED_MEMOIZE !== 'true') {
@@ -76,13 +76,11 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       }
 
       if (this.nodeInfo.trackInputChanges === true) {
-        let obj = {};
-        this.inputNodeWrappers.forEach((wrap, idx) => {
-          let revision = this.inputRevisions.get(wrap);
-          obj[idx] = revision ? revision.changed : true;
-        });
+        let changed = this.inputNodeWrappers.map(
+          wrapper => this.inputRevisions.get(wrapper).changed
+        );
 
-        resolve(this.callbackObject.build({ changedNodes: obj }));
+        resolve(this.callbackObject.build({ changedNodes: changed }));
       } else {
         resolve(this.callbackObject.build());
       }

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -27,17 +27,6 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       return true;
     }
 
-    // Memoization is currently optin via BROCCOLI_ENABLED_MEMOIZE = true
-    if (process.env.BROCCOLI_ENABLED_MEMOIZE !== 'true') {
-      return true;
-    }
-
-    // The plugin has no input nodes so it's build method should not
-    // be called after the first build
-    if (this.inputNodeWrappers.length === 0 && this.revision === 0) {
-      return true;
-    }
-
     let nodesThatChanged = [];
     this.inputNodeWrappers.forEach(wrapper => {
       let wrapper_revision_meta = this.inputRevisions.get(wrapper);
@@ -49,6 +38,17 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
         this.inputRevisions.set(wrapper, { revision: wrapper.revision, changed: false });
       }
     });
+
+    // Memoization is currently optin via BROCCOLI_ENABLED_MEMOIZE = true
+    if (process.env.BROCCOLI_ENABLED_MEMOIZE !== 'true') {
+      return true;
+    }
+
+    // The plugin has no input nodes so it's build method should not
+    // be called after the first build
+    if (this.inputNodeWrappers.length === 0 && this.revision === 0) {
+      return true;
+    }
 
     if (nodesThatChanged.length > 0) {
       logger.debug(`${this.id} built because inputNodes [${nodesThatChanged.join(', ')}] changed`);

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -42,7 +42,7 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     this.inputNodeWrappers.forEach(wrapper => {
       let wrapper_revision_meta = this.inputRevisions.get(wrapper);
 
-      if (wrapper_revision_meta && wrapper_revision_meta.revision !== wrapper.revision) {
+      if (!wrapper_revision_meta || wrapper_revision_meta.revision !== wrapper.revision) {
         nodesThatChanged.push(wrapper.id);
         this.inputRevisions.set(wrapper, { revision: wrapper.revision, changed: true });
       } else {
@@ -77,7 +77,8 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
 
       let obj = {};
       this.inputNodeWrappers.forEach((wrap, idx) => {
-        obj[idx] = this.inputRevisions.get(wrap).changed;
+        let revision = this.inputRevisions.get(wrap);
+        obj[idx] = revision ? revision.changed : true;
       });
 
       resolve(this.callbackObject.build({ changedNodes: obj }));

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -75,13 +75,17 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
         fs.mkdirSync(this.outputPath);
       }
 
-      let obj = {};
-      this.inputNodeWrappers.forEach((wrap, idx) => {
-        let revision = this.inputRevisions.get(wrap);
-        obj[idx] = revision ? revision.changed : true;
-      });
+      if (this.nodeInfo.trackInputChanges === true) {
+        let obj = {};
+        this.inputNodeWrappers.forEach((wrap, idx) => {
+          let revision = this.inputRevisions.get(wrap);
+          obj[idx] = revision ? revision.changed : true;
+        });
 
-      resolve(this.callbackObject.build({ changedNodes: obj }));
+        resolve(this.callbackObject.build({ changedNodes: obj }));
+      } else {
+        resolve(this.callbackObject.build());
+      }
 
       this.revise();
     }).then(() => {

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -19,6 +19,11 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     // If the any inputNode's ref does not match what is stored in here then we
     // know a modification has happened so we call the build method
     this.inputRevisions = new WeakMap();
+    this.nodeMap = new WeakMap();
+
+    this.callbackObject.hasInputNodeChanged = node => {
+      return this.nodeMap.get(node) || true;
+    };
   }
 
   shouldBuild() {
@@ -43,6 +48,9 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
       if (this.inputRevisions.get(wrapper) !== wrapper.revision) {
         nodesThatChanged.push(wrapper.id);
         this.inputRevisions.set(wrapper, wrapper.revision);
+        this.nodeMap.set(wrapper.node, true);
+      } else {
+        this.nodeMap.set(wrapper.node, false);
       }
     });
 

--- a/lib/wrappers/transform-node.js
+++ b/lib/wrappers/transform-node.js
@@ -19,11 +19,6 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
     // If the any inputNode's ref does not match what is stored in here then we
     // know a modification has happened so we call the build method
     this.inputRevisions = new WeakMap();
-    this.nodeMap = new WeakMap();
-
-    this.callbackObject.hasInputNodeChanged = node => {
-      return this.nodeMap.get(node) || true;
-    };
   }
 
   shouldBuild() {
@@ -45,12 +40,13 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
 
     let nodesThatChanged = [];
     this.inputNodeWrappers.forEach(wrapper => {
-      if (this.inputRevisions.get(wrapper) !== wrapper.revision) {
+      let wrapper_revision_meta = this.inputRevisions.get(wrapper);
+
+      if (wrapper_revision_meta && wrapper_revision_meta.revision !== wrapper.revision) {
         nodesThatChanged.push(wrapper.id);
-        this.inputRevisions.set(wrapper, wrapper.revision);
-        this.nodeMap.set(wrapper.node, true);
+        this.inputRevisions.set(wrapper, { revision: wrapper.revision, changed: true });
       } else {
-        this.nodeMap.set(wrapper.node, false);
+        this.inputRevisions.set(wrapper, { revision: wrapper.revision, changed: false });
       }
     });
 
@@ -79,7 +75,12 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
         fs.mkdirSync(this.outputPath);
       }
 
-      resolve(this.callbackObject.build());
+      let obj = {};
+      this.inputNodeWrappers.forEach((wrap, idx) => {
+        obj[idx] = this.inputRevisions.get(wrap).changed;
+      });
+
+      resolve(this.callbackObject.build({ changedNodes: obj }));
 
       this.revise();
     }).then(() => {

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -93,20 +93,14 @@ describe('transform-node', function() {
 
     await transform.build(); // initial build
     chai.expect(spy).to.have.been.calledWith({
-      changedNodes: {
-        0: true,
-        1: true,
-      },
+      changedNodes: [true, true],
     });
 
     inputWrapperB.revise();
 
     await transform.build();
     chai.expect(spy).to.have.been.calledWith({
-      changedNodes: {
-        0: false,
-        1: true,
-      },
+      changedNodes: [false, true],
     });
 
     inputWrapperA.revise();
@@ -114,19 +108,13 @@ describe('transform-node', function() {
 
     await transform.build();
     chai.expect(spy).to.have.been.calledWith({
-      changedNodes: {
-        0: true,
-        1: true,
-      },
+      changedNodes: [true, true],
     });
 
     await transform.build();
 
     chai.expect(spy).to.have.been.calledWith({
-      changedNodes: {
-        0: false,
-        1: false,
-      },
+      changedNodes: [false, false],
     });
   });
 });

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -91,7 +91,7 @@ describe('transform-node', function() {
 
     transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
 
-    await transform.build(); // initial build
+    await transform.build();
     chai.expect(spy).to.have.been.calledWith({
       changedNodes: [true, true],
     });
@@ -116,5 +116,35 @@ describe('transform-node', function() {
     chai.expect(spy).to.have.been.calledWith({
       changedNodes: [false, false],
     });
+  });
+
+  it('build should not receive an object if trackInputChanges is false / undefined', async function() {
+    const spy = sinon.spy();
+
+    transform.nodeInfo.build = spy;
+    // transform.nodeInfo.trackInputChanges is undefined
+
+    let inputWrapperA = new Node();
+    let inputWrapperB = new Node();
+
+    transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
+
+    await transform.build();
+    chai.expect(spy).to.have.been.calledWith();
+
+    inputWrapperB.revise();
+
+    await transform.build();
+    chai.expect(spy).to.have.been.calledWith();
+
+    transform.nodeInfo.trackInputChanges = false;
+ 
+    await transform.build();
+    chai.expect(spy).to.have.been.calledWith();
+
+    inputWrapperB.revise();
+
+    await transform.build();
+    chai.expect(spy).to.have.been.calledWith();
   });
 });

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -138,7 +138,7 @@ describe('transform-node', function() {
     chai.expect(spy).to.have.been.calledWith();
 
     transform.nodeInfo.trackInputChanges = false;
- 
+
     await transform.build();
     chai.expect(spy).to.have.been.calledWith();
 

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -1,8 +1,13 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon').createSandbox();
 const Node = require('../lib/wrappers/node');
 const TransformNode = require('../lib/wrappers/transform-node');
+const { expect } = chai;
+
+chai.use(sinonChai);
 
 describe('transform-node', function() {
   let transform;
@@ -73,5 +78,55 @@ describe('transform-node', function() {
     expect(transform.shouldBuild()).to.be.true;
     inputWrapperA.revise();
     expect(transform.shouldBuild()).to.be.true;
+  });
+
+  it('build should receive object if trackInputChanges is true', async function() {
+    const spy = sinon.spy();
+
+    transform.nodeInfo.build = spy;
+    transform.nodeInfo.trackInputChanges = true;
+
+    let inputWrapperA = new Node();
+    let inputWrapperB = new Node();
+
+    transform.inputNodeWrappers = [inputWrapperA, inputWrapperB];
+
+    await transform.build(); // initial build
+    chai.expect(spy).to.have.been.calledWith({
+      changedNodes: {
+        0: true,
+        1: true,
+      },
+    });
+
+    inputWrapperB.revise();
+
+    await transform.build();
+    chai.expect(spy).to.have.been.calledWith({
+      changedNodes: {
+        0: false,
+        1: true,
+      },
+    });
+
+    inputWrapperA.revise();
+    inputWrapperB.revise();
+
+    await transform.build();
+    chai.expect(spy).to.have.been.calledWith({
+      changedNodes: {
+        0: true,
+        1: true,
+      },
+    });
+
+    await transform.build();
+
+    chai.expect(spy).to.have.been.calledWith({
+      changedNodes: {
+        0: false,
+        1: false,
+      },
+    });
   });
 });


### PR DESCRIPTION
## Background
This PR adds opt-in input node change tracking. If enabled, Broccoli will pass an object as the first argument into the build method of plugins when invoking them. We are passing an object as it will give us greater flexibility to add additional properties later.

## Implementation
The type of this object is:

```typescript
interface BuildObject {
  changedNodes: boolean[]
}
```

By default this will not be passed into the build method. To enable this feature, plugins must pass `trackInputChanges`:

```js
class MyPlugin extends Plugin {
  constructor(inputNodes) {
    super(inputNodes, {
      trackInputChanges: true
    });
  }
}
```

## Use Case

The primary use case for this feature is to enable "selective building". An example of this is if your plugin takes several inputs and performs some action on each inputPath. This can become inefficient with either a large number of inputs or if your action is expensive. Currently plugin authors have to create their own diffing solution which generally is inefficient due to having to touch the filesystem. This feature leverages the revision tracking system and thus can efficiently inform plugins on *which* node has changed. A concrete example of where it will be used is in `embroider` to allow addons to be rebuilt: https://github.com/embroider-build/embroider/pull/297.

## Example

```js
const fs = require("fs");
const Plugin = require("broccoli-plugin");
const { WatchedDir } = require("broccoli-source");

class MyPlugin extends Plugin {
  constructor(inputNodes) {
    super(inputNodes, {
      trackInputChanges: true
    });
  }

  build({ changedNodes }) {
    this.inputPaths.forEach((path, idx) => {
        if (changedNodes[idx]) {
          const input = fs.readFileSync(`${this.inputPaths[idx]}/foo.txt`);
          fs.writeFileSync(`${this.outputPath}/${idx}-foo.txt`, input);
        }
    });
  }
}

export default () => {
  let app = new WatchedDir("app");
  let foo = new WatchedDir("foo");

  return new MyPlugin([app, foo]);
};
```