### PR TITLE
Convert errors to Typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parserOptions: {
     ecmaVersion: 2018,
-    sourceTyp: 'module',
+    sourceType: 'module',
   },
   plugins: ['node', 'prettier'],
   extends: ['eslint:recommended', 'plugin:node/recommended'],
@@ -17,7 +17,8 @@ module.exports = {
     'prettier/prettier': ['error', require('./prettier.config')],
     "node/no-missing-require": ["error", {
       "tryExtensions": ['.js', '.json', '.node', '.ts']
-    }]
+    }],
+    'node/no-unsupported-features': 0
   },
   overrides: [
     {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,3 +1,7 @@
+import NodeWrapper from './wrappers/node';
+import TransformNodeWrapper from './wrappers/transform-node';
+import SourceNodeWrapper from './wrappers/source-node';
+
 const promiseFinally = require('promise.prototype.finally');
 const path = require('path');
 const fs = require('fs');
@@ -7,10 +11,6 @@ const heimdall = require('heimdalljs');
 const underscoreString = require('underscore.string');
 const WatchedDir = require('broccoli-source').WatchedDir;
 const broccoliNodeInfo = require('broccoli-node-info');
-
-const NodeWrapper = require('./wrappers/node');
-const TransformNodeWrapper = require('./wrappers/transform-node');
-const SourceNodeWrapper = require('./wrappers/source-node');
 
 const BuilderError = require('./errors/builder');
 const NodeSetupError = require('./errors/node-setup');

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -12,11 +12,11 @@ const underscoreString = require('underscore.string');
 const WatchedDir = require('broccoli-source').WatchedDir;
 const broccoliNodeInfo = require('broccoli-node-info');
 
-const BuilderError = require('./errors/builder');
-const NodeSetupError = require('./errors/node-setup');
-const BuildError = require('./errors/build');
-const CancelationRequest = require('./cancelation-request');
-const Cancelation = require('./errors/cancelation');
+import BuilderError from './errors/builder';
+import NodeSetupError from './errors/node-setup';
+import BuildError from './errors/build';
+import CancelationRequest from './cancelation-request';
+import Cancelation from './errors/cancelation';
 const logger = require('heimdalljs-logger')('broccoli:builder');
 const filterMap = require('./utils/filter-map');
 

--- a/lib/cancelation-request.js
+++ b/lib/cancelation-request.js
@@ -1,4 +1,4 @@
-const CancelationError = require('./errors/cancelation');
+import CancelationError from './errors/cancelation';
 
 module.exports = class CancelationRequest {
   constructor(pendingWork) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,7 +8,7 @@ const UI = require('console-ui');
 
 const broccoli = require('./index');
 const messages = require('./messages');
-const CliError = require('./errors/cli');
+import CliError from './errors/cli';
 
 module.exports = function broccoliCLI(args, ui = new UI()) {
   // always require a fresh commander, as it keeps state at module scope

--- a/lib/errors/build.ts
+++ b/lib/errors/build.ts
@@ -1,10 +1,15 @@
-const BuilderError = require('./builder');
+import BuilderError from './builder';
 const wrapPrimitiveErrors = require('../utils/wrap-primitive-errors');
 
-module.exports = class BuildError extends BuilderError {
-  constructor(originalError, nodeWrapper) {
+export default class BuildError extends BuilderError {
+  isSilent: any;
+  isCancellation: any;
+  broccoliPayload: any;
+
+  constructor(originalError: any, nodeWrapper: any) {
     if (nodeWrapper == null) {
       // for Chai
+      // @ts-ignore
       super();
       return;
     }
@@ -41,6 +46,7 @@ module.exports = class BuildError extends BuilderError {
       nodeWrapper.label +
       instantiationStack;
 
+    // @ts-ignore
     super(message);
     // consider for x in y
     this.stack = originalError.stack;

--- a/lib/errors/builder.ts
+++ b/lib/errors/builder.ts
@@ -1,21 +1,24 @@
 // Base class for builder errors
-module.exports = class Cancelation extends Error {
-  static isCancelationError(e) {
-    return typeof e === 'object' && e !== null && e.isCancelation === true;
+export default class BuilderError extends Error {
+  stack: any;
+  message: any;
+  isBuilderError: any;
+
+  static isBuilderError(error: any) {
+    return error !== null && typeof error === 'object' && error.isBuilderError;
   }
 
-  constructor(a, b, c) {
+  constructor(a: any, b: any, c: any) {
     // Subclassing Error in ES5 is non-trivial because reasons, so we need this
     // extra constructor logic from http://stackoverflow.com/a/17891099/525872.
     // Note that ES5 subclasses of BuilderError don't in turn need any special
     // code.
-    let temp = super(a, b, c);
+    // @ts-ignore
+    let temp: any = super(a, b, c);
     // Need to assign temp.name for correct error class in .stack and .message
     temp.name = this.name = this.constructor.name;
     this.stack = temp.stack;
     this.message = temp.message;
-
-    this.isCancelation = true;
-    this.isSilent = true;
+    this.isBuilderError = true;
   }
 };

--- a/lib/errors/cancelation.ts
+++ b/lib/errors/cancelation.ts
@@ -1,19 +1,27 @@
 // Base class for builder errors
-module.exports = class BuilderError extends Error {
-  static isBuilderError(error) {
-    return error !== null && typeof error === 'object' && error.isBuilderError;
+export default class Cancelation extends Error {
+  stack: any;
+  message: any;
+  isCancelation: any;
+  isSilent: any;
+
+  static isCancelationError(e: any) {
+    return typeof e === 'object' && e !== null && e.isCancelation === true;
   }
 
-  constructor(a, b, c) {
+  constructor(a: any, b: any, c: any) {
     // Subclassing Error in ES5 is non-trivial because reasons, so we need this
     // extra constructor logic from http://stackoverflow.com/a/17891099/525872.
     // Note that ES5 subclasses of BuilderError don't in turn need any special
     // code.
-    let temp = super(a, b, c);
+    // @ts-ignore
+    let temp: any = super(a, b, c);
     // Need to assign temp.name for correct error class in .stack and .message
     temp.name = this.name = this.constructor.name;
     this.stack = temp.stack;
     this.message = temp.message;
-    this.isBuilderError = true;
+
+    this.isCancelation = true;
+    this.isSilent = true;
   }
 };

--- a/lib/errors/cli.js
+++ b/lib/errors/cli.js
@@ -1,2 +1,0 @@
-// Base class for cli errors
-module.exports = class CliError extends Error {};

--- a/lib/errors/cli.ts
+++ b/lib/errors/cli.ts
@@ -1,0 +1,2 @@
+// Base class for cli errors
+export default class CliError extends Error {};

--- a/lib/errors/node-setup.ts
+++ b/lib/errors/node-setup.ts
@@ -1,10 +1,13 @@
-const BuilderError = require('./builder');
+import BuilderError from './builder';
 const wrapPrimitiveErrors = require('../utils/wrap-primitive-errors');
 
-module.exports = class NodeSetupError extends BuilderError {
-  constructor(originalError, nodeWrapper) {
+export default class NodeSetupError extends BuilderError {
+  stack: any;
+
+  constructor(originalError: any, nodeWrapper: any) {
     if (nodeWrapper == null) {
       // Chai calls new NodeSetupError() :(
+      // @ts-ignore
       super();
       return;
     }
@@ -14,6 +17,7 @@ module.exports = class NodeSetupError extends BuilderError {
       '\nat ' +
       nodeWrapper.label +
       nodeWrapper.formatInstantiationStackForTerminal();
+    // @ts-ignore
     super(message);
     // The stack will have the original exception name, but that's OK
     this.stack = originalError.stack;

--- a/lib/watcher_adapter.js
+++ b/lib/watcher_adapter.js
@@ -1,7 +1,8 @@
+import SourceNode from './wrappers/source-node';
+
 const EventEmitter = require('events').EventEmitter;
 const sane = require('sane');
 const logger = require('heimdalljs-logger')('broccoli:watcherAdapter');
-const SourceNode = require('./wrappers/source-node');
 
 function defaultFilterFunction(name) {
   return /^[^.]/.test(name);

--- a/lib/wrappers/node.ts
+++ b/lib/wrappers/node.ts
@@ -1,8 +1,23 @@
 'use strict';
 
 const undefinedToNull = require('../utils/undefined-to-null');
+import { NodeInfo } from 'broccoli-node-api';
 
-module.exports = class NodeWrapper {
+export default class NodeWrapper {
+  _revision: number;
+  buildState: {
+    selfTime?: number;
+    totalTime?: number;
+    built?: boolean;
+  };
+
+  id!: number;
+  label!: string;
+  cachePath!: string;
+  outputPath!: string;
+  nodeInfo!: NodeInfo;
+  inputNodeWrappers!: any[];
+
   constructor() {
     this.buildState = {};
     this._revision = 0;
@@ -32,4 +47,8 @@ module.exports = class NodeWrapper {
   formatInstantiationStackForTerminal() {
     return '\n-~- created here: -~-\n' + this.nodeInfo.instantiationStack + '\n-~- (end) -~-';
   }
+
+  nodeInfoToJSON() {
+    return {};  
+  };
 };

--- a/lib/wrappers/source-node.ts
+++ b/lib/wrappers/source-node.ts
@@ -1,9 +1,13 @@
 'use strict';
-const NodeWrapper = require('./node');
-const fs = require('fs');
+
+import NodeWrapper from './node';
+import * as fs from 'fs';
+import { SourceNodeInfo } from 'broccoli-node-api';
 const undefinedToNull = require('../utils/undefined-to-null');
 
-module.exports = class SourceNodeWrapper extends NodeWrapper {
+export default class SourceNodeWrapper extends NodeWrapper {
+  nodeInfo!: SourceNodeInfo;
+
   setup(/* features */) {}
   build() {
     // We only check here that the sourceDirectory exists and is a directory

--- a/lib/wrappers/transform-node.ts
+++ b/lib/wrappers/transform-node.ts
@@ -1,13 +1,20 @@
 'use strict';
 
-const NodeWrapper = require('./node');
+import NodeWrapper from './node';
+import { TransformNodeInfo } from 'broccoli-node-api';
 const fs = require('fs');
 const undefinedToNull = require('../utils/undefined-to-null');
 const rimraf = require('rimraf');
 const logger = require('heimdalljs-logger')('broccoli:transform-node');
 
-module.exports = class TransformNodeWrapper extends NodeWrapper {
-  setup(features) {
+export default class TransformNodeWrapper extends NodeWrapper {
+  inputRevisions!: WeakMap<any, { revision: number, changed: boolean }>;
+  callbackObject: any;
+  inputPaths!: string[];
+  nodeInfo!: TransformNodeInfo;
+
+
+  setup(features: any) {
     this.nodeInfo.setup(features, {
       inputPaths: this.inputPaths,
       outputPath: this.outputPath,
@@ -22,8 +29,8 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
   }
 
   shouldBuild() {
-    let nodesThatChanged = [];
-    this.inputNodeWrappers.forEach(wrapper => {
+    let nodesThatChanged: any[] = [];
+    this.inputNodeWrappers.forEach((wrapper: any) => {
       let wrapper_revision_meta = this.inputRevisions.get(wrapper);
 
       if (!wrapper_revision_meta || wrapper_revision_meta.revision !== wrapper.revision) {
@@ -60,7 +67,7 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
   }
 
   build() {
-    let startTime;
+    let startTime: [number, number];
 
     return new Promise(resolve => {
       startTime = process.hrtime();
@@ -77,7 +84,7 @@ module.exports = class TransformNodeWrapper extends NodeWrapper {
 
       if (this.nodeInfo.trackInputChanges === true) {
         let changed = this.inputNodeWrappers.map(
-          wrapper => this.inputRevisions.get(wrapper).changed
+          wrapper => this.inputRevisions.get(wrapper)!.changed
         );
 
         resolve(this.callbackObject.build({ changedNodes: changed }));

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.1",
+    "broccoli-node-api": "^1.7.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "copyfiles": "^2.1.1",

--- a/test/cancelation-request-test.js
+++ b/test/cancelation-request-test.js
@@ -2,7 +2,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const chaiAsPromised = require('chai-as-promised');
 const CancelationRequest = require('../lib/cancelation-request');
-const CancelationError = require('../lib/errors/cancelation');
+import CancelationError from '../lib/errors/cancelation';
 
 chai.use(chaiAsPromised);
 

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -7,7 +7,7 @@ const sinon = require('sinon').createSandbox();
 const sinonChai = require('sinon-chai');
 
 const Builder = require('../lib/builder');
-const BuilderError = require('../lib/errors/builder');
+import BuilderError from '../lib/errors/builder';
 const DummyWatcher = require('../lib/dummy-watcher');
 const broccoli = require('../lib/index');
 const cli = require('../lib/cli');

--- a/test/watcher_adapter_test.js
+++ b/test/watcher_adapter_test.js
@@ -1,6 +1,7 @@
+import TransformNodeWrapper from '../lib/wrappers/transform-node';
+import SourceNodeWrapper from '../lib/wrappers/source-node';
+
 const WatcherAdapter = require('../lib/watcher_adapter');
-const TransformNodeWrapper = require('../lib/wrappers/transform-node');
-const SourceNodeWrapper = require('../lib/wrappers/source-node');
 const bindFileEvent = WatcherAdapter.bindFileEvent;
 const fs = require('fs');
 const chai = require('chai');

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -1,6 +1,6 @@
-const Watcher = require('../lib/watcher');
-const SourceNodeWrapper = require('../lib/wrappers/source-node');
+import SourceNodeWrapper from '../lib/wrappers/source-node';
 
+const Watcher = require('../lib/watcher');
 const path = require('path');
 const chai = require('chai');
 const expect = chai.expect;

--- a/test/wrappers_test.js
+++ b/test/wrappers_test.js
@@ -1,8 +1,9 @@
+import Node from '../lib/wrappers/node';
+import TransformNode from '../lib/wrappers/transform-node';
+
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 const sinon = require('sinon').createSandbox();
-const Node = require('../lib/wrappers/node');
-const TransformNode = require('../lib/wrappers/transform-node');
 const { expect } = chai;
 
 chai.use(sinonChai);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "declaration": false,
     "strict": true,
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "module": "commonjs",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,7 +248,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-broccoli-node-api@^1.6.0:
+broccoli-node-api@^1.6.0, broccoli-node-api@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/broccoli-node-api/-/broccoli-node-api-1.7.0.tgz#391aa6edecd2a42c63c111b4162956b2fa288cb6"
   integrity sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw==


### PR DESCRIPTION
This requires #428 to be merged first (this is a commit ontop of #428 which will have to be rebased once it is merged). This continues converting the code base over to typescript by converting everything in errors.

WIP: Still need to convert the `any`'s