### PR TITLE
[BUGFIX] no longer cause spurious unhandled promise rejections warnings

### DIFF
--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -145,7 +145,6 @@ class Builder extends EventEmitter {
 
     try {
       await pipeline;
-      this._cancelationRequest.throwIfRequested();
       this.buildHeimdallTree(this.outputNodeWrapper);
     } finally {
       let buildsSkipped = filterMap(

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "lint:fix": "eslint --fix lib test",
     "prepare": "yarn build",
     "pretest": "multidep test/multidep.json",
-    "test": "yarn build && mocha -r ts-node/register -r source-map-support/register",
-    "test:debug": "yarn build && mocha --inspect-brk -r ts-node/register -r source-map-support/register",
+    "test": "yarn build && mocha -r ts-node/register -r source-map-support/register -r ./test/utils/throw-on-unhandled-rejection",
+    "test:debug": "yarn build && mocha --inspect-brk -r ts-node/register -r source-map-support/register  -r ./test/utils/throw-on-unhandled-rejection",
     "watch": "tsc --watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "lint:fix": "eslint --fix lib test",
     "prepare": "yarn build",
     "pretest": "multidep test/multidep.json",
-    "test": "yarn build && mocha -r ts-node/register -r source-map-support/register -r ./test/utils/throw-on-unhandled-rejection",
-    "test:debug": "yarn build && mocha --inspect-brk -r ts-node/register -r source-map-support/register  -r ./test/utils/throw-on-unhandled-rejection",
+    "test": "yarn build && mocha -r test/utils/requires",
+    "test:debug": "yarn build && mocha --inspect-brk -r test/utils/requires",
     "watch": "tsc --watch"
   },
   "dependencies": {
@@ -78,6 +78,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "fixturify": "^0.3.4",
     "got": "^9.0.0",
+    "longjohn": "^0.2.12",
     "mocha": "^5.2.0",
     "mocha-eslint": "^4.1.0",
     "multidep": "^2.0.2",

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -920,7 +920,7 @@ describe('Builder', function() {
       await wait();
 
       const next = Promise.all([
-        expect(build).to.eventually.be.rejectedWith('Build Canceled'),
+        expect(build).to.eventually.be.fulfilled,
         pipeline.cancel(),
         expect(pipeline.build()).to.eventually.be.rejectedWith(
           'Cannot start a build if one is already running'

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -141,7 +141,7 @@ describe('server', function() {
     const watcher = new Watcher(builder, []);
 
     server = new Server.Server(watcher, '127.0.0.1', PORT, undefined, mockUI);
-    server.start();
+    server.start().catch(() => {});
 
     await new Promise((resolve, reject) => {
       server.instance.on('listening', resolve);

--- a/test/utils/requires.js
+++ b/test/utils/requires.js
@@ -1,3 +1,5 @@
+require('ts-node/register');
+require('longjohn');
 process.on('unhandledRejection', reason => {
   throw reason;
 });

--- a/test/utils/throw-on-unhandled-rejection.js
+++ b/test/utils/throw-on-unhandled-rejection.js
@@ -1,0 +1,3 @@
+process.on('unhandledRejection', reason => {
+  throw reason;
+});

--- a/test/watcher_test.js
+++ b/test/watcher_test.js
@@ -113,7 +113,7 @@ describe('Watcher', function() {
       watcher.on('debounce', debounceHandler);
       watcher.on('buildStart', buildStartHandler);
       watcher.on('buildSuccess', buildEndHandler);
-
+      // TODO: stop using mocks, spies and private API's
       watcher._ready = true;
       await watcher._change('change', 'file.js', 'root');
       expect(changeHandler).to.have.been.calledWith('change', 'file.js', 'root');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,6 +2076,13 @@ lolex@^4.1.0:
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.1.0.tgz#ecdd7b86539391d8237947a3419aa8ac975f0fe1"
   integrity sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==
 
+longjohn@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/longjohn/-/longjohn-0.2.12.tgz#7ca7446b083655c377e7512213dc754d52a64a7e"
+  integrity sha1-fKdEawg2VcN351EiE9x1TVKmSn4=
+  dependencies:
+    source-map-support "0.3.2 - 1.0.0"
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -2954,7 +2961,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.16:
+"source-map-support@0.3.2 - 1.0.0", source-map-support@^0.5.16:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==


### PR DESCRIPTION
This PR fixes broccoli to no longer unintentionally trigger node's `unhandledRejection` warnings.

Specifically these warnings where coming from `watcher.currentBuild` which is a public API, allowing external consumers to consider the latest builds outcome. For example the broccoli express middleware will on each request follow `watcher.currentBuild`. On fulfillment it will serve the file in question, or on rejection it will provide a useful error page.

`watcher.currentBuild` is the downstream promise of several internal watcher promises, each of which already handle rejections correctly appropriately.

This commit ensures external consumers of `currentBuild` are correctly notified of the final promise state, but without any external consumers rejections of `currentBuild` are considered handled.

---

The test here is the addition of failing the test if there are any unhandled rejection warnings.