### PR TITLE
[feature] add a buildFinished event to builder

### DIFF
--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -170,6 +170,8 @@ class Builder extends EventEmitter {
       await pipeline;
       this.buildHeimdallTree(this.outputNodeWrapper);
     } finally {
+      this.emit('buildFinished', pipeline);
+
       let buildsSkipped = filterMap(
         this._nodeWrappers.values(),
         (nw: NodeWrappers) => nw.buildState.built === false

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -344,6 +344,25 @@ describe('Builder', function() {
       });
     });
 
+    it('should emit buildFinished after builder has finished', async function() {
+      let isFinishedWasCalled = false;
+
+      builder = new FixtureBuilder('test/fixtures/basic');
+
+      builder.on('buildFinished', () => {
+        isFinishedWasCalled = true;
+      });
+
+      expect(builder.watchedPaths).to.deep.equal([path.resolve('test/fixtures/basic')]);
+      expect(builder.unwatchedPaths).to.deep.equal([]);
+
+      await expect(builder.build()).to.eventually.deep.equal({
+        'foo.txt': 'OK',
+      });
+
+      expect(isFinishedWasCalled).to.equal(true);
+    });
+
     it('records source directories only once', function() {
       const src = 'test/fixtures/basic';
 


### PR DESCRIPTION
# Motivation

I am currently working on a project that requires knowing when a builder has finished without blocking on waiting on the current build.

This allows me to subscribe to events just like the _beginNode_ and _endNode_ events. 