### PR TITLE
Exit process with code 1 when build fails

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -254,14 +254,20 @@ export = function broccoliCLI(args: string[], ui = new UI()) {
       process.on('SIGTERM', cleanupAndExit);
 
       actionPromise = (async () => {
+        let buildFailed = false;
         try {
           await watcher.start();
         } catch (e) {
+          buildFailed = true;
           ui.writeError(e);
         } finally {
           try {
             builder.cleanup();
-            process.exit(0);
+            if (buildFailed) {
+              process.exit(1);
+            } else {
+              process.exit(0);
+            }
           } catch (e) {
             ui.writeLine('Cleanup error:', 'ERROR');
             ui.writeError(e);

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -94,6 +94,17 @@ describe('cli', function() {
       });
     });
 
+    context('on failed build', function() {
+      it('closes process with exit code 1', async function() {
+        sinon.stub(DummyWatcher.prototype, 'start').value(() => {
+          throw new Error('Build failed');
+        });
+
+        await cli(['node', 'broccoli', 'build', 'dist']);
+        chai.expect(exitStub).to.be.calledWith(1);
+      });
+    });
+
     context('overwrites existing [target]', function() {
       afterEach(() => {
         rimraf.sync('dist');


### PR DESCRIPTION
**Why**
Currently when a build fails broccoli-cli exits with code 0. This causes a lot of different tools that rely on exit code to assume that build succeeded even though it in fact failed

**How**
- Added a flag buildFailed and toggled it if the catch block is invoked
- Swapped exit code to 1 in the finally block based on that flag