### PR TITLE
remove vestigial filter option

### DIFF
--- a/lib/watcher_adapter.ts
+++ b/lib/watcher_adapter.ts
@@ -7,18 +7,10 @@ import HeimdallLogger from 'heimdalljs-logger';
 
 const logger = new HeimdallLogger('broccoli:watcherAdapter');
 
-interface WatcherAdapterOptions extends sane.Options {
-  filter?: (name: string) => boolean;
-}
-
-function defaultFilterFunction(name: string) {
-  return /^[^.]/.test(name);
-}
-
 class WatcherAdapter extends EventEmitter {
   watchers: sane.Watcher[];
   watchedNodes: SourceNodeWrapper[];
-  options: WatcherAdapterOptions;
+  options: sane.Options;
 
   constructor(watchedNodes: SourceNodeWrapper[], options: sane.Options = {}) {
     super();
@@ -37,7 +29,6 @@ class WatcherAdapter extends EventEmitter {
     }
     this.watchedNodes = watchedNodes;
     this.options = options;
-    this.options.filter = this.options.filter || defaultFilterFunction;
     this.watchers = [];
   }
 

--- a/test/watcher_adapter_test.js
+++ b/test/watcher_adapter_test.js
@@ -122,30 +122,6 @@ describe('WatcherAdapter', function() {
       expect(() => WatcherAdapter()).to.throw(/\bwithout 'new'/);
     });
 
-    it('has defaults', function() {
-      const adapter = new WatcherAdapter([]);
-
-      expect(adapter.options).to.have.keys('filter');
-      expect(adapter.options.filter).to.have.be.a('Function');
-    });
-
-    it('supports custom options, but without filter', function() {
-      const customOptions = {};
-      const adapter = new WatcherAdapter([], customOptions);
-
-      expect(adapter.options).to.eql(customOptions);
-      expect(adapter.options.filter).to.have.be.a('Function');
-    });
-
-    it('supports custom options, and allows for a  custom filter', function() {
-      function filter() {}
-      const customOptions = { filter };
-      const adapter = new WatcherAdapter([], customOptions);
-
-      expect(adapter.options).to.eql(customOptions);
-      expect(adapter.options.filter).to.eql(filter);
-    });
-
     it('throws if you try to watch a non array', function() {
       [NaN, {}, { length: 0 }, 'string', function() {}, Symbol('OMG')].forEach(arg => {
         expect(() => new WatcherAdapter(arg)).to.throw(


### PR DESCRIPTION
This option has no effect. sane doesn't take a `filter` option and never has. 

I think it's only here because of what broccoli-sane-watcher did https://github.com/broccolijs/broccoli-sane-watcher/blob/master/index.js#L105