### PR TITLE
add the ability to ignore absolute paths from watcher

### DIFF
--- a/lib/watcher.ts
+++ b/lib/watcher.ts
@@ -11,6 +11,10 @@ interface WatcherOptions {
   debounce?: number;
   watcherAdapter?: WatcherAdapter;
   saneOptions?: sane.Options;
+
+  // list of absolute paths that we should not watch, even if they end up nested
+  // beneath dirs that we are watching.
+  ignored?: string[];
 }
 
 // This Watcher handles all the Broccoli logic, such as debouncing. The
@@ -43,7 +47,8 @@ class Watcher extends EventEmitter {
     this._currentBuild = Promise.resolve();
     this.builder = builder;
     this.watcherAdapter =
-      this.options.watcherAdapter || new WatcherAdapter(watchedNodes, this.options.saneOptions);
+      this.options.watcherAdapter ||
+      new WatcherAdapter(watchedNodes, this.options.saneOptions, this.options.ignored);
 
     this._rebuildScheduled = false;
     this._ready = false;

--- a/lib/watcher_adapter.ts
+++ b/lib/watcher_adapter.ts
@@ -4,6 +4,7 @@ import SourceNode from './wrappers/source-node';
 import SourceNodeWrapper from './wrappers/source-node';
 import bindFileEvent from './utils/bind-file-event';
 import HeimdallLogger from 'heimdalljs-logger';
+import { isAbsolute, relative } from 'path';
 
 const logger = new HeimdallLogger('broccoli:watcherAdapter');
 
@@ -11,8 +12,13 @@ class WatcherAdapter extends EventEmitter {
   watchers: sane.Watcher[];
   watchedNodes: SourceNodeWrapper[];
   options: sane.Options;
+  private ignored: string[] | undefined;
 
-  constructor(watchedNodes: SourceNodeWrapper[], options: sane.Options = {}) {
+  constructor(
+    watchedNodes: SourceNodeWrapper[],
+    options: sane.Options = {},
+    ignored: string[] | undefined = undefined
+  ) {
     super();
     if (!Array.isArray(watchedNodes)) {
       throw new TypeError(
@@ -29,13 +35,14 @@ class WatcherAdapter extends EventEmitter {
     }
     this.watchedNodes = watchedNodes;
     this.options = options;
+    this.ignored = ignored;
     this.watchers = [];
   }
 
   watch() {
     const watchers = this.watchedNodes.map((node: SourceNodeWrapper) => {
       const watchedPath = node.nodeInfo.sourceDirectory;
-      const watcher = sane(watchedPath, this.options);
+      const watcher = sane(watchedPath, this.optionsFor(watchedPath));
       this.watchers.push(watcher);
       bindFileEvent(this, watcher, node, 'change');
       bindFileEvent(this, watcher, node, 'add');
@@ -72,6 +79,26 @@ class WatcherAdapter extends EventEmitter {
     this.watchers.length = 0;
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return Promise.all(closing).then(() => {});
+  }
+
+  private optionsFor(watchedPath: string): sane.Options {
+    let options = this.options;
+    if (this.ignored) {
+      // we need to convert any absolute ignored paths to local paths that sit
+      // within the watchedPath
+      const localIgnored = this.ignored
+        .map(ignoredAbsPath => {
+          const ignoredRelativePath = relative(watchedPath, ignoredAbsPath);
+          if (!ignoredRelativePath.startsWith('..') && !isAbsolute(ignoredRelativePath)) {
+            return ignoredRelativePath + '/**';
+          }
+        })
+        .filter(Boolean) as string[];
+      if (localIgnored.length > 0) {
+        options = Object.assign({}, options, { ignored: localIgnored });
+      }
+    }
+    return options;
   }
 }
 

--- a/lib/watcher_adapter.ts
+++ b/lib/watcher_adapter.ts
@@ -7,18 +7,10 @@ import HeimdallLogger from 'heimdalljs-logger';
 
 const logger = new HeimdallLogger('broccoli:watcherAdapter');
 
-interface WatcherAdapterOptions extends sane.Options {
-  filter?: (name: string) => boolean;
-}
-
-function defaultFilterFunction(name: string) {
-  return /^[^.]/.test(name);
-}
-
 class WatcherAdapter extends EventEmitter {
   watchers: sane.Watcher[];
   watchedNodes: SourceNodeWrapper[];
-  options: WatcherAdapterOptions;
+  options: sane.Options;
 
   constructor(watchedNodes: SourceNodeWrapper[], options: sane.Options = {}) {
     super();
@@ -37,7 +29,6 @@ class WatcherAdapter extends EventEmitter {
     }
     this.watchedNodes = watchedNodes;
     this.options = options;
-    this.options.filter = this.options.filter || defaultFilterFunction;
     this.watchers = [];
   }
 

--- a/test/watcher_adapter_test.js
+++ b/test/watcher_adapter_test.js
@@ -6,6 +6,7 @@ import TransformNodeWrapper from '../lib/wrappers/transform-node';
 import SourceNodeWrapper from '../lib/wrappers/source-node';
 import WatcherAdapter from '../lib/watcher_adapter';
 import bindFileEvent from '../lib/utils/bind-file-event';
+import { join } from 'path';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -232,6 +233,27 @@ describe('WatcherAdapter', function() {
           });
         });
       });
+    });
+  });
+  describe('optionsFor', function() {
+    let adapter;
+    beforeEach(function() {
+      adapter = new WatcherAdapter([], {}, [join(__dirname, 'my-ignored-subdir')]);
+    });
+    afterEach(async function() {
+      await adapter.quit();
+    });
+    it('generates a relative ignored path inside watchedDir', function() {
+      const options = adapter.optionsFor(__dirname);
+      expect(options.ignored).to.deep.eq(['my-ignored-subdir/**']);
+    });
+    it('generates no relative ignored paths when they are outside watchedDir', function() {
+      const options = adapter.optionsFor('/somewhere/else');
+      expect(options.ignored).to.eq(undefined);
+    });
+    it('is not fooled by name prefix matches', function() {
+      const options = adapter.optionsFor(join(__dirname, 'my-ignored-subdir-just-kidding'));
+      expect(options.ignored).to.eq(undefined);
     });
   });
 });

--- a/test/watcher_adapter_test.js
+++ b/test/watcher_adapter_test.js
@@ -122,30 +122,6 @@ describe('WatcherAdapter', function() {
       expect(() => WatcherAdapter()).to.throw(/\bwithout 'new'/);
     });
 
-    it('has defaults', function() {
-      const adapter = new WatcherAdapter([]);
-
-      expect(adapter.options).to.have.keys('filter');
-      expect(adapter.options.filter).to.have.be.a('Function');
-    });
-
-    it('supports custom options, but without filter', function() {
-      const customOptions = {};
-      const adapter = new WatcherAdapter([], customOptions);
-
-      expect(adapter.options).to.eql(customOptions);
-      expect(adapter.options.filter).to.have.be.a('Function');
-    });
-
-    it('supports custom options, and allows for a  custom filter', function() {
-      function filter() {}
-      const customOptions = { filter };
-      const adapter = new WatcherAdapter([], customOptions);
-
-      expect(adapter.options).to.eql(customOptions);
-      expect(adapter.options.filter).to.eql(filter);
-    });
-
     it('throws if you try to watch a non array', function() {
       [NaN, {}, { length: 0 }, 'string', function() {}, Symbol('OMG')].forEach(arg => {
         expect(() => new WatcherAdapter(arg)).to.throw(


### PR DESCRIPTION
(This PR builds off https://github.com/broccolijs/broccoli/pull/473, for a smaller review see only https://github.com/broccolijs/broccoli/commit/5fda57e0645855fcd0186af9919af7e0caea8f26.)

This adds an option to mark certain absolute paths as ignored by the watcher.

The motivation here is that if you want to be able to rebuild arbitrary node packages (which can put their source code at the top level of their project if they want to), and those packages emit build artifacts into some of their own subdirectories (like `dist` as used by ember-cli), you end up watching your own output.

In this situation, it is straightforward to know which path(s) are your own output, and tell broccoli not to watch them.

`sane`'s `ignored` option is perfect for this, except that it's always relative to the watchedDir, so broccoli's Watcher must translate.