### PR TITLE
Manually exit process

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -157,8 +157,7 @@ export = function broccoliCLI(args: string[], ui = new UI()) {
         } catch (e) {
           if (e instanceof CliError) {
             ui.writeError(e);
-            process.exitCode = 1;
-            return;
+            return process.exit(1);
           }
 
           throw e;
@@ -197,8 +196,7 @@ export = function broccoliCLI(args: string[], ui = new UI()) {
     .action((outputDir: string, options: BuildOptions) => {
       if (outputDir && options.outputPath) {
         ui.writeLine('option --output-path and [target] cannot be passed at same time', 'ERROR');
-        process.exitCode = 1;
-        return;
+        return process.exit(1);
       }
 
       if (options.outputPath) {
@@ -220,8 +218,7 @@ export = function broccoliCLI(args: string[], ui = new UI()) {
       } catch (e) {
         if (e instanceof CliError) {
           ui.writeError(e);
-          process.exitCode = 1;
-          return;
+          return process.exit(1);
         }
 
         throw e;
@@ -271,10 +268,11 @@ export = function broccoliCLI(args: string[], ui = new UI()) {
             if (!process.exitCode) {
               process.exitCode = 0;
             }
+            process.exit(process.exitCode);
           } catch (e) {
             ui.writeLine('Cleanup error:', 'ERROR');
             ui.writeError(e);
-            process.exitCode = 1;
+            process.exit(1);
           }
         }
       })();
@@ -286,6 +284,6 @@ export = function broccoliCLI(args: string[], ui = new UI()) {
     return actionPromise;
   } else {
     program.outputHelp();
-    process.exitCode = 1;
+    process.exit(1);
   }
 };

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -165,11 +165,12 @@ function serve(
       if (!_process.exitCode) {
         _process.exitCode = 0;
       }
+      _process.exit(_process.exitCode);
     })
     .catch(err => {
       ui.writeLine('Broccoli Cleanup error:', 'ERROR');
       ui.writeError(err);
-      _process.exitCode = 1;
+      _process.exit(1);
     });
 }
 

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -35,9 +35,11 @@ function createWatcherSpy() {
 
 describe('cli', function() {
   let oldCwd = null;
+  let exitStub;
   const EXIT_CODE = process.exitCode;
 
   beforeEach(function() {
+    exitStub = sinon.stub(process, 'exit');
     oldCwd = process.cwd();
     process.chdir('test/fixtures/project/subdir');
   });
@@ -86,6 +88,7 @@ describe('cli', function() {
       it('closes process on completion', async function() {
         await cli(['node', 'broccoli', 'build', 'dist']);
         chai.expect(process.exitCode).to.eql(0);
+        chai.expect(exitStub).to.be.calledWith(0);
       });
 
       it('creates output folder', async function() {
@@ -146,7 +149,7 @@ describe('cli', function() {
         chai
           .expect(mockUI.errors)
           .to.contain('build directory can not be the current or direct parent directory: /');
-        chai.expect(process.exitCode).to.eql(1);
+        chai.expect(exitStub).to.be.calledWith(1);
       });
     });
 
@@ -162,6 +165,7 @@ describe('cli', function() {
       it('closes process on completion', async function() {
         await cli(['node', 'broccoli', 'build', 'dist', '--watcher', 'polling']);
         chai.expect(process.exitCode).to.eql(0);
+        chai.expect(exitStub).to.be.calledWith(0);
       });
 
       it('creates watcher with sane options for polling', async function() {
@@ -221,6 +225,7 @@ describe('cli', function() {
       it('closes process on completion', async function() {
         await cli(['node', 'broccoli', 'build', 'dist', '--brocfile-path', '../Brocfile.js']);
         chai.expect(process.exitCode).to.eql(0);
+        chai.expect(exitStub).to.be.calledWith(0);
       });
 
       it('loads brocfile from a path', async function() {
@@ -243,6 +248,7 @@ describe('cli', function() {
             '../../empty/Brocfile.js',
           ]);
           chai.expect(process.exitCode).eql(0);
+          chai.expect(exitStub).to.be.calledWith(0);
         });
       });
     });
@@ -300,12 +306,14 @@ describe('cli', function() {
     it('supports `b` alias', async function() {
       await cli(['node', 'broccoli', 'b']);
       chai.expect(process.exitCode).to.eql(0);
+      chai.expect(exitStub).to.be.calledWith(0);
     });
 
     context('with param --output-path', function() {
       it('closes process on completion', async function() {
         await cli(['node', 'broccoli', 'build', '--output-path', 'dist']);
         chai.expect(process.exitCode).to.eql(0);
+        chai.expect(exitStub).to.be.calledWith(0);
       });
 
       it('creates output folder', async function() {
@@ -316,7 +324,7 @@ describe('cli', function() {
       context('and with [target]', function() {
         it('exits with error', function() {
           cli(['node', 'broccoli', 'build', 'dist', '--output-path', 'dist']);
-          chai.expect(process.exitCode).to.eql(1);
+          chai.expect(exitStub).to.be.calledWith(1);
         });
 
         it('outputs error reason to console', function() {


### PR DESCRIPTION
Partial revert of https://github.com/broccolijs/broccoli/pull/476
to work around https://github.com/babel/broccoli-babel-transpiler/issues/169

Kept the tests and ensuring the correct exit code is called, but put back the manual process exiting.