### PR TITLE
feat: CORS headers for served assets

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -134,6 +134,9 @@ function handleRequest(
     return;
   }
 
+  response.setHeader('Access-Control-Allow-Origin', '*');
+  response.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+
   response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
   response.setHeader('Content-Length', stat.size);
   response.setHeader('Content-Type', mime.contentType(path.extname(filename)));

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -202,6 +202,8 @@ describe('server', function() {
       expect(body).to.eql('Hello');
       expect(headers['last-modified']).to.eql('Fri, 27 Jul 2018 17:23:02 GMT');
       expect(headers['cache-control']).to.eql('private, max-age=0, must-revalidate');
+      expect(headers['access-control-allow-origin']).to.eql('*');
+      expect(headers['access-control-allow-methods']).to.eql('GET, OPTIONS');
       expect(headers['content-length']).to.eql('5');
       expect(headers['content-type']).to.eql('text/plain; charset=utf-8');
     }


### PR DESCRIPTION
Use case:

* Static Java application with it's own serving logic and port (port: 5000)
* Broccoli server running in parallel, to simplify frontend development (port: 4200)

We point to broccoli-served assets from port 5000 to 4200 and getting CORS error.

This MR introduce CORS headers for static assets, and should solve this error.
