### PR TITLE
Remove https npm library as it doesn't and cannot do anything

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "handlebars": "^4.7.3",
     "heimdalljs": "^0.2.6",
     "heimdalljs-logger": "^0.1.9",
-    "https": "^1.0.0",
     "mime-types": "^2.1.26",
     "resolve-path": "^1.4.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
https is a package with a package.json and nothing more. the import for require("https") is reserved by node so the package is unable to do anything even if it had more code so it's reasonable to remove the package in order to prevent any issues with the package.

Should not be a critical issue any time soon